### PR TITLE
Workaround to avoid an infinite loop when generating dependencies within Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ java:
 	(cd japron; $(MAKE))
 
 ml:
-	(cd mlapronidl; $(MAKE) all)
+	(cd mlapronidl; $(MAKE) INCLUDE_DEPEND=no depend; $(MAKE) all)
 	(cd newpolka; $(MAKE) ml)
 	(cd box; $(MAKE) ml)
 	(cd octagons; $(MAKE) mlMPQ mlD)

--- a/mlapronidl/Makefile
+++ b/mlapronidl/Makefile
@@ -222,10 +222,13 @@ rebuild:
 # Dependencies
 #---------------------------------------
 
-depend: $(MLMODULES:%=%.ml) $(MLMODULES:%=%.mli)
+INCLUDE_DEPEND ?= yes
+ifneq ($(INCLUDE_DEPEND),yes)
+  depend: $(MLMODULES:%=%.ml) $(MLMODULES:%=%.mli)
 	$(OCAMLDEP) $^ > $@
-
-# Hack to avoid rebuilding depends on cleanup
-ifeq ($(filter %clean,$(MAKECMDGOALS)),)
-  -include depend
+else
+  # Hack to avoid rebuilding depends on cleanup
+  ifeq ($(filter %clean,$(MAKECMDGOALS)),)
+    -include depend
+  endif
 endif


### PR DESCRIPTION
This change mostly concerns the build system for OCaml bindings. It avoids an infinite loop in the build system, that was triggered when the package is built under some versions of Docker and GNU make (as done by some continuous integration builds automatically performed on every package pushed to the official OPAM repository).