### PR TITLE
Use mpfr_rootn_ui instead of deprecated mpfr_root

### DIFF
--- a/num/numflt_mpfr.h
+++ b/num/numflt_mpfr.h
@@ -123,8 +123,13 @@ static inline void numflt_root(numflt_t up, numflt_t down, numflt_t b, unsigned 
 {
   assert(n > 0);
   assert((n & 1) || (mpfr_sgn(b) >= 0));
+#if (MPFR_VERSION_MAJOR < 4)
   mpfr_root(up, b, n, GMP_RNDU);
   mpfr_root(down, b, n, GMP_RNDD);
+#else
+  mpfr_rootn_ui(up, b, n, GMP_RNDU);
+  mpfr_rootn_ui(down, b, n, GMP_RNDD);
+#endif
 }
 static inline void numflt_mul_2exp(numflt_t a, numflt_t b, int c)
 { mpfr_mul_2si(a,b,c,GMP_RNDU); }

--- a/num/numflt_native.h
+++ b/num/numflt_native.h
@@ -188,18 +188,34 @@ static inline void numflt_root(numflt_t up, numflt_t down, numflt_t b, unsigned 
 #if defined(NUMFLT_DOUBLE)
   mpfr_init_set_d(arg, *b, GMP_RNDU);
   mpfr_init(res);
+#if (MPFR_VERSION_MAJOR < 4)
   mpfr_root(res, arg, n, GMP_RNDU);
+#else
+  mpfr_rootn_ui(res, arg, n, GMP_RNDU);
+#endif
   *up = mpfr_get_d(res, GMP_RNDU);
   mpfr_set_d(arg, *b, GMP_RNDD);
+#if (MPFR_VERSION_MAJOR < 4)
   mpfr_root(res, arg, n, GMP_RNDD);
+#else
+  mpfr_rootn_ui(res, arg, n, GMP_RNDD);
+#endif
   *down = mpfr_get_d(res, GMP_RNDD);
 #else
   mpfr_init_set_ld(arg, *b, GMP_RNDU);
   mpfr_init(res);
+#if (MPFR_VERSION_MAJOR < 4)
   mpfr_root(res, arg, n, GMP_RNDU);
+#else
+  mpfr_rootn_ui(res, arg, n, GMP_RNDU);
+#endif
   *up = mpfr_get_ld(res, GMP_RNDU);
   mpfr_set_ld(arg, *b, GMP_RNDD);
+#if (MPFR_VERSION_MAJOR < 4)
   mpfr_root(res, arg, n, GMP_RNDD);
+#else
+  mpfr_rootn_ui(res, arg, n, GMP_RNDD);
+#endif
   *down = mpfr_get_ld(res, GMP_RNDD);
 #endif
   mpfr_clear(arg);


### PR DESCRIPTION
Hello, I am Sungkeun Cho developing a buffer overrun checker of Infer at Facebook (with @mbouaziz). Thank you for moving the repository to GitHub. :purple_heart:

We have a plan of using the Apron library in our checker for preciser analysis results. For that, we need to add missing serialization functions for `ap_environment`, `var_ptr`, etc. I am preparing a pull request for this.

Before sending the pull request, I would like to resolve existing compilation warnings, so I can be sure there is no warnings from the code I will add and understand Apron code a bit more myself.

******

`mpfr_root` has been deprecated since version 4.0.0 and will be removed in the future. So in this pull request, it uses `mpfr_rootn_ui` instead. [Their semantics](https://www.mpfr.org/mpfr-4.0.0/mpfr.html#index-mpfr_005frootn_005fui) are slightly different, so please let me know if the change is not acceptable.