### PR TITLE
Fixed memory leak in t1p_meet_lincons_array

### DIFF
--- a/taylor1plus/t1p_constructor.c
+++ b/taylor1plus/t1p_constructor.c
@@ -59,7 +59,8 @@ t1p_t* t1p_of_box(ap_manager_t* man, size_t intdim, size_t realdim, ap_interval_
 {
     CALL();
     t1p_internal_t* pr = t1p_init_from_manager(man, AP_FUNID_OF_BOX);
-    itv_t* itv_array = itv_array_alloc(intdim+realdim);
+    //itv_t* itv_array = itv_array_alloc(intdim+realdim);
+    itv_t* itv_array;
     itv_array_set_ap_interval_array(pr->itv, &itv_array, tinterval, intdim+realdim);
     t1p_t* res = t1p_alloc(man,intdim,realdim);
     size_t i = 0;

--- a/taylor1plus/t1p_internal.h
+++ b/taylor1plus/t1p_internal.h
@@ -600,6 +600,9 @@ static inline t1p_nsym_t* t1p_nsym_add(t1p_internal_t *pr, nsym_t type)
     /* resize epsilon array */
     if ((dim+1) % 1024 == 0) pr->epsilon = (t1p_nsym_t**)realloc(pr->epsilon, (dim+1024)*sizeof(t1p_nsym_t*));
     res = pr->epsilon[dim] = (t1p_nsym_t*)malloc(sizeof(t1p_nsym_t));
+    if ((pr->epssize+1) % 1024 == 0) {
+      pr->inputns = (uint_t*) realloc(pr->inputns, (pr->epssize+1024) * sizeof(uint_t));
+    }
     if (type == IN) {pr->inputns[pr->epssize] = dim; pr->epssize++;}
     res->index = dim;
     res->type = type;

--- a/taylor1plus/t1p_meetjoin.c
+++ b/taylor1plus/t1p_meetjoin.c
@@ -392,10 +392,12 @@ t1p_t* t1p_meet_tcons_array(ap_manager_t* man, bool destructive, t1p_t* a, ap_tc
 	} else {
 	    /* nothing change */
 	}
-	itv_lincons_array_clear(&itv_lincons_array);
     } else {
 	/* bottom */
 	is_bottom = true;
+    }
+    if (array->p != NULL) {
+      itv_lincons_array_clear(&itv_lincons_array);
     }
     if (!is_bottom) {
 	/* texpr -> aff forme */

--- a/taylor1plus/t1p_meetjoin.c
+++ b/taylor1plus/t1p_meetjoin.c
@@ -322,6 +322,7 @@ t1p_t* t1p_meet_lincons_array(ap_manager_t* man, bool destructive, t1p_t* a, ap_
     t1p_fprint(stdout, man, res, NULL);
     fprintf(stdout, "### ### ###\n");
 #endif
+    ap_tcons0_array_clear(&tcons0_array);
     return res;
 }
 


### PR DESCRIPTION
There was a memory leak in `t1p_meet_lincons_array` where the constructed `texpr0_array` is never freed. This is just a very small patch to fix that problem.