### PR TITLE
Import OPAM package specification

### DIFF
--- a/apron.opam
+++ b/apron.opam
@@ -1,0 +1,44 @@
+opam-version: "2.0"
+synopsis: "APRON numerical abstract domain library"
+authors: [
+  "Bertrand Jeannet"
+  "Antoine Miné"
+  "https://github.com/antoinemine/apron/graphs/contributors"
+]
+license: "LGPL-2.1 with linking exception"
+homepage: "http://apron.cri.ensmp.fr/library/"
+maintainer: "Nicolas Berthier <m@nberth.space>"
+dev-repo: "git+https://github.com/antoinemine/apron.git"
+bug-reports: "https://github.com/antoinemine/apron/issues"
+build: [
+  [
+    "sh"
+    "./configure"
+    "--prefix"
+    "%{share}%/apron"
+    "--no-ppl" {!conf-ppl:installed}
+    "--no-java"
+    "--no-ocaml-plugins" {os = "freebsd"}
+    "--absolute-dylibs" {os = "macos"}
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: [
+  ["ocamlfind" "remove" "apron"]
+  ["rm" "-r" "-f" "%{share}%/apron"]
+]
+depends: [
+  "ocaml"
+  "ocamlfind"
+  "camlidl"
+  "mlgmpidl"
+  "ocamlbuild" {build}
+  "conf-perl"
+]
+depopts: [
+  "conf-ppl"
+]
+flags: light-uninstall

--- a/apron.opam
+++ b/apron.opam
@@ -17,7 +17,6 @@ build: [
     "--prefix"
     "%{share}%/apron"
     "--no-ppl" {!conf-ppl:installed}
-    "--no-java"
     "--no-ocaml-plugins" {os = "freebsd"}
     "--absolute-dylibs" {os = "macos"}
   ]

--- a/japron/Makefile
+++ b/japron/Makefile
@@ -54,7 +54,7 @@ GMPMODS = Mpz MpzRef Mpq Mpfr RandState
 # lone .java
 GMPJAVA = Test
 
-APRONLIBS = -ljgmp -lboxD -loctD -lpolkaMPQ -lapron $(GMPLIBS)
+APRONLIBS = -lboxD -loctD -lpolkaMPQ -lapron -ljgmp $(GMPLIBS)
 
 # .java / .c pairs
 APRONMODS = Dimchange Dimperm Linexpr0 Lincons0 \


### PR DESCRIPTION
Publishing an OPAM package has become quite easy since version 2.0 and the introduction of the `opam-publish` plugin (see [here](https://opam.ocaml.org/doc/Packaging.html#If-the-project-is-hosted-on-Github)), especially with this new `apron.opam` file.