### PR TITLE
fix build java bindings

### DIFF
--- a/configure
+++ b/configure
@@ -567,8 +567,8 @@ JAVAC     = $javac -Xlint:unchecked
 JAVAH     = $javah
 JAVADOC   = $javadoc
 JAR       = $jar
-JAVA_HOME = $java_home
-JNIINC    = -I$java_home/include
+java_home = ${JAVA_HOME}
+jniinc    = -I${JAVA_HOME}/INCLUDE
 
 CC = $cc
 CFLAGS = -U__STRICT_ANSI__ -DNDEBUG -O3 $cflags

--- a/japron/Makefile
+++ b/japron/Makefile
@@ -20,6 +20,7 @@ IFLAGS = $(ICFLAGS) \
 -I$(MPFR_PREFIX)/include \
 -I$(PPL_PREFIX)/include \
 -I${JAVA_HOME}/include \
+-I${JAVA_HOME}/include/linux \
 -I../apron \
 -I../box \
 -I../newpolka \

--- a/japron/Makefile
+++ b/japron/Makefile
@@ -19,6 +19,7 @@ IFLAGS = $(ICFLAGS) \
 -I$(GMP_PREFIX)/include \
 -I$(MPFR_PREFIX)/include \
 -I$(PPL_PREFIX)/include \
+-I${JAVA_HOME}/include \
 -I../apron \
 -I../box \
 -I../newpolka \


### PR DESCRIPTION
It seems that JAVA_HOME is capital sensitive in configure and japron's parent ICFLAGS does not include JNI include path