### PR TITLE
tentative fix for issue #17

### DIFF
--- a/apron/ap_lincons0.c
+++ b/apron/ap_lincons0.c
@@ -75,6 +75,8 @@ bool ap_lincons0_is_unsat(ap_lincons0_t* cons)
 	return (sgn<0);
       case AP_CONS_SUP:
 	return (sgn<=0);
+      default:
+        abort();
       }
     case AP_COEFF_INTERVAL:
       sgn = ap_scalar_sgn(expr->cst.val.interval->sup);
@@ -92,6 +94,8 @@ bool ap_lincons0_is_unsat(ap_lincons0_t* cons)
 	return sgn<0;
       case AP_CONS_SUP:
 	return (sgn<=0);
+      default:
+        abort();
       }
     default:
       abort();
@@ -128,6 +132,8 @@ bool ap_lincons0_is_sat(ap_lincons0_t* cons)
 	return ap_scalar_sgn(expr->cst.val.scalar)>=0;
       case AP_CONS_SUP:
 	return ap_scalar_sgn(expr->cst.val.scalar)>0;
+      default:
+        abort();
       }
     case AP_COEFF_INTERVAL:
       if (ap_interval_is_bottom(expr->cst.val.interval)) 
@@ -148,6 +154,8 @@ bool ap_lincons0_is_sat(ap_lincons0_t* cons)
       case AP_CONS_SUP:
 	return 
           ap_scalar_sgn(expr->cst.val.interval->inf)>0;
+      default:
+        abort();
       }
     default:
       abort();

--- a/apron/ap_linearize_aux.c
+++ b/apron/ap_linearize_aux.c
@@ -431,6 +431,7 @@ ITVFUN(ap_intlinearize_tcons0_array)(ap_manager_t* man,
   ap_lincons0_array_t res;
   size_t i;
   bool change = false;
+  bool empty = false;
   bool* tchange = NULL;
 
   if (pexact) *pexact = false;
@@ -446,7 +447,7 @@ ITVFUN(ap_intlinearize_tcons0_array)(ap_manager_t* man,
       (intervalonly ? !itv_lincons_array_is_quasilinear(&tlincons) : true)){
     tchange = malloc((dim.intdim+dim.realdim)*2);
     for (i=0;i<(dim.intdim+dim.realdim)*2;i++) tchange[i]=false;
-    change = itv_boxize_lincons_array(&intern,env,tchange,&tlincons,env,dim.intdim,kmax,intervalonly);
+    change = itv_boxize_lincons_array(&intern,env,tchange,&tlincons,env,dim.intdim,kmax,intervalonly,&empty);
   }
   switch(linearize){
   case AP_LINEXPR_INTLINEAR:
@@ -465,7 +466,7 @@ ITVFUN(ap_intlinearize_tcons0_array)(ap_manager_t* man,
     goto ap_intlinearize_tcons0_array_exit;
   
   if (change){
-    if (itv_is_bottom(&intern,env[0])){
+    if (empty){
       itv_lincons_array_reinit(&tlincons,1);
       itv_lincons_set_bool(&tlincons.p[0],false);
       goto ap_intlinearize_tcons0_array_exit;

--- a/box/box_meetjoin.c
+++ b/box/box_meetjoin.c
@@ -173,6 +173,7 @@ box_t* box_meet_lincons_array(ap_manager_t* man,
 			      box_t* a,
 			      ap_lincons0_array_t* array)
 {
+  bool empty = false;
   box_t* res;
   size_t kmax;
   itv_lincons_array_t tlincons;
@@ -196,8 +197,8 @@ box_t* box_meet_lincons_array(ap_manager_t* man,
     }
     itv_boxize_lincons_array(intern->itv,
 			     res->p,NULL,
-			     &tlincons,res->p,a->intdim,kmax,false);
-    if (itv_is_bottom(intern->itv,res->p[0])){
+			     &tlincons,res->p,a->intdim,kmax,false,&empty);
+    if (empty){
     _box_meet_lincons_array_bottom:
       box_set_bottom(res);
     }
@@ -212,6 +213,7 @@ box_t* box_meet_tcons_array(ap_manager_t* man,
 			    box_t* a,
 			    ap_tcons0_array_t* array)
 {
+  bool empty = false;
   box_t* res;
   int kmax;
   box_internal_t* intern = (box_internal_t*)man->internal;
@@ -240,8 +242,8 @@ box_t* box_meet_tcons_array(ap_manager_t* man,
       }
       itv_boxize_lincons_array(intern->itv,
                                res->p,NULL,
-                               &tlincons,res->p,a->intdim,kmax,false);
-      if (itv_is_bottom(intern->itv,res->p[0])){
+                               &tlincons,res->p,a->intdim,kmax,false,&empty);
+      if (empty){
       _box_meet_tcons_array_bottom:
         box_set_bottom(res);
       }

--- a/itv/itv_linearize.c
+++ b/itv/itv_linearize.c
@@ -95,7 +95,8 @@ static bool itv_boxize_lincons(itv_internal_t* intern,
 			       itv_lincons_t* cons,
 			       itv_t* env,
 			       size_t intdim,
-			       bool intervalonly)
+			       bool intervalonly,
+                               bool* empty)
 {
   size_t i;
   itv_linexpr_t* expr;
@@ -108,6 +109,7 @@ static bool itv_boxize_lincons(itv_internal_t* intern,
 
   expr = &cons->linexpr;
   globalchange = false;
+  *empty = false;
 
   /* Iterates on coefficients */
   itv_set_int(intern->boxize_lincons_itv,0);
@@ -352,7 +354,7 @@ static bool itv_boxize_lincons(itv_internal_t* intern,
   }
   if (expr->size==0 &&
       itv_eval_cstlincons(intern,cons)==tbool_false){
-    itv_set_bottom(res[0]);
+    *empty = true;
     globalchange = true;
   }
   return globalchange;
@@ -378,7 +380,8 @@ bool ITVFUN(itv_boxize_lincons_array)(itv_internal_t* intern,
 				      itv_lincons_array_t* array,
 				      itv_t* env,size_t intdim,
 				      size_t kmax,
-				      bool intervalonly)
+				      bool intervalonly,
+                                      bool *empty)
 {
   size_t i,k;
   bool change,globalchange;
@@ -395,12 +398,12 @@ bool ITVFUN(itv_boxize_lincons_array)(itv_internal_t* intern,
 	  array->p[i].constyp==AP_CONS_SUPEQ ||
 	  array->p[i].constyp==AP_CONS_SUP){
 	change =
-	  itv_boxize_lincons(intern,res,tchange,&array->p[i],env,intdim,intervalonly)
+	  itv_boxize_lincons(intern,res,tchange,&array->p[i],env,intdim,intervalonly,empty)
 	  ||
 	  change
 	  ;
 	globalchange = globalchange || change;
-	if (itv_is_bottom(intern,res[0])){
+	if (*empty){
 	  return true;
 	}
       }

--- a/itv/itv_linearize.h
+++ b/itv/itv_linearize.h
@@ -43,7 +43,8 @@ static inline bool itv_boxize_lincons_array(itv_internal_t* intern,
 					    itv_lincons_array_t* array,
 					    itv_t* env,size_t intdim,
 					    size_t kmax,
-					    bool intervalonly);
+					    bool intervalonly,
+                                            bool* empty);
   /* Deduce interval constraints from a set of interval linear constraints.
 
      Return true if some bounds have been inferred.
@@ -140,7 +141,7 @@ void ITVFUN(itv_eval_linexpr)(itv_internal_t* intern, itv_t itv, itv_linexpr_t* 
 bool ITVFUN(itv_eval_ap_linexpr0)(itv_internal_t* intern, itv_t itv, ap_linexpr0_t* expr, itv_t* env);
 
 /* II. Boxization of interval linear expressions */
-bool ITVFUN(itv_boxize_lincons_array)(itv_internal_t* intern, itv_t* res, bool* change, itv_lincons_array_t* array, itv_t* env, size_t intdim, size_t kmax, bool intervalonly);
+bool ITVFUN(itv_boxize_lincons_array)(itv_internal_t* intern, itv_t* res, bool* change, itv_lincons_array_t* array, itv_t* env, size_t intdim, size_t kmax, bool intervalonly, bool* empty);
 
 /* III. (Quasi)linearisation of interval linear expressions and constraints */
 bool ITVFUN(itv_quasilinearize_linexpr)(itv_internal_t* intern, itv_linexpr_t* linexpr, itv_t* env, bool for_meet_inequality);
@@ -175,8 +176,8 @@ static inline bool itv_eval_ap_linexpr0(itv_internal_t* intern, itv_t itv, ap_li
 { return ITVFUN(itv_eval_ap_linexpr0)(intern,itv,expr,env); }
 
 /* II. Boxization of interval linear expressions */
-static inline bool itv_boxize_lincons_array(itv_internal_t* intern, itv_t* res, bool* tchange, itv_lincons_array_t* array, itv_t* env, size_t intdim, size_t kmax, bool intervalonly)
-{ return ITVFUN(itv_boxize_lincons_array)(intern,res,tchange,array,env,intdim,kmax,intervalonly); }
+static inline bool itv_boxize_lincons_array(itv_internal_t* intern, itv_t* res, bool* tchange, itv_lincons_array_t* array, itv_t* env, size_t intdim, size_t kmax, bool intervalonly, bool* empty)
+{ return ITVFUN(itv_boxize_lincons_array)(intern,res,tchange,array,env,intdim,kmax,intervalonly,empty); }
 
 /* III. (Quasi)linearisation of interval linear expressions and constraints */
 static inline bool itv_quasilinearize_linexpr(itv_internal_t* intern, itv_linexpr_t* linexpr, itv_t* env, bool for_ineq)

--- a/taylor1plus/t1p_meetjoin.c
+++ b/taylor1plus/t1p_meetjoin.c
@@ -354,6 +354,7 @@ t1p_t* t1p_meet_tcons_array(ap_manager_t* man, bool destructive, t1p_t* a, ap_tc
     size_t kmax = 2; /* specifies the maximum number of iterations */
 
     bool* tchange = (bool*)calloc(2*a->dims, sizeof(bool));
+    bool empty = false;
     itv_t box; itv_init(box);
     itv_lincons_array_t itv_lincons_array;
     itv_lincons_array.size = 0;
@@ -361,7 +362,7 @@ t1p_t* t1p_meet_tcons_array(ap_manager_t* man, bool destructive, t1p_t* a, ap_tc
     if (!itv_intlinearize_ap_tcons0_array(pr->itv, &itv_lincons_array, array, res->box, res->intdim)) {
 	size_t kmax = 2; /* specifies the maximum number of iterations */
 	/* intervalonly is set to false which means try to improve all dimensions, not only the ones with an interval coefficient */
-	if (itv_boxize_lincons_array(pr->itv, res->box, tchange, &itv_lincons_array, res->box, res->intdim, kmax, false)) {
+	if (itv_boxize_lincons_array(pr->itv, res->box, tchange, &itv_lincons_array, res->box, res->intdim, kmax, false, &empty)) {
 	    /* there is some inferred bounds */
 	    for (i=0; i<res->dims; i++) {
 		if (tchange[2*i] || tchange[2*i + 1]) {


### PR DESCRIPTION
itv_boxize_lincons returns emptyness information in a speficit out-argument instead of res[0], which may not be allocated if the environment is empty