### PR TITLE
Do not autodetect perl

### DIFF
--- a/configure
+++ b/configure
@@ -364,7 +364,7 @@ fi
 searchbinreq "ar"; ar="$path"
 searchbinreq "ranlib"; ranlib="$path"
 searchbinreq "sed"; sed="$path"
-searchbinreq "perl"; perl="$path"
+#searchbinreq "perl"; perl="$path"
 searchbinreq "install"; install="$path"
 
 
@@ -583,7 +583,7 @@ EXT_DLL = $ext_dll
 AR = $ar
 RANLIB = $ranlib
 SED = $sed
-PERL = $perl
+PERL = perl
 INSTALL = $install
 INSTALLd = $install -d
 


### PR DESCRIPTION
/usr/bin/perl does not work on windows, you need c:/usr/bin/perl instead.
'perl' works everywhere, so let's use this