### PR TITLE
Switch from texi2dvi & texi2html to texi2any

### DIFF
--- a/Makefile.config.model
+++ b/Makefile.config.model
@@ -178,7 +178,6 @@ LATEX=latex
 PDFLATEX=pdflatex
 DVIPDF=dvipdf
 MAKEINDEX=makeindex
-TEXI2DVI=texi2dvi
-TEXI2HTML=texi2html
+TEXI2ANY=texi2any
 
 OCAMLPACK = $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/ocamlpack

--- a/apron/Makefile
+++ b/apron/Makefile
@@ -106,15 +106,15 @@ newpolka.texi: ../newpolka/newpolka.texi
 box.texi: ../box/box.texi
 	ln -sf $< $@
 
-apron.pdf: apron.texi rationale.texi ap_pkgrid.texi ap_ppl.texi newpolka.texi box.texi 
-	$(TEXI2DVI) --pdf -o $@ $<
+apron.pdf: apron.texi rationale.texi ../products/ap_pkgrid.texi ../ppl/ap_ppl.texi ../newpolka/newpolka.texi ../box/box.texi 
+	$(TEXI2ANY) --pdf -o $@ $<
 
 apron.info: apron.texi rationale.texi ap_pkgrid.texi ap_ppl.texi newpolka.texi box.texi
 	$(MAKEINFO) -o $@ $<
 
 
 html: apron.texi rationale.texi ap_pkgrid.texi ap_ppl.texi newpolka.texi box.texi 
-	$(TEXI2HTML) -split=section -nonumber-sections -menu -subdir=html $<
+	$(TEXI2ANY) --html --split=section --no-number-sections $<
 	cp -f ../octagons/oct_doc.html html
 
 #---------------------------------------

--- a/apron/apron.texi
+++ b/apron/apron.texi
@@ -67,6 +67,7 @@ numerical variables.
 @contents
 @end ifnothtml
 
+@ifnottex
 @menu
 * Copying::
 * Introduction to APRON::
@@ -80,6 +81,7 @@ numerical variables.
 * Examples::
 * Appendices::
 @end menu
+@end ifnottex
 
 @c *******************************************************************
 @node Copying, Introduction to APRON, Top, Top
@@ -2470,7 +2472,8 @@ Polynomial fraction with possibly interval coefficients, no rounding
 @end deftypefun
 
 @deftypefun bool ap_texpr1_is_scalar (ap_texpr1_t* @var{e})
-All coefficients are scalar (non-interval)@end deftypefun
+All coefficients are scalar (non-interval)
+@end deftypefun
 
 @c -------------------------------------------------------------------
 @node Operations on tree expressions of level 1,  , Tests on tree expressions of level 1, Tree expressions of level 1

--- a/configure
+++ b/configure
@@ -621,8 +621,7 @@ LATEX = latex
 PDFLATEX = pdflatex
 DVIPDF = dvipdf
 MAKEINDEX = makeindex
-TEXI2DVI = texi2dvi
-TEXI2HTML = texi2html
+TEXI2ANY = texi2any
 
 # OSX only:
 ABSOLUTE_DYLIB_INSTALL_NAMES = $absolute_dylib_install_names


### PR DESCRIPTION
texi2html is dead upstream since 2011, texi2any on the other hand is still being developed.

This PR makes the documentation buildable with texi2any.


Original patch by: Jerry James for the Fedora RPM