### PR TITLE
add -L flags when linking native plugin

### DIFF
--- a/vars.mk
+++ b/vars.mk
@@ -73,7 +73,7 @@ ifneq ($(HAS_SHARED),)
     CXX_APRON_DYLIB += -install_name $(APRON_LIB)/$@
   endif
   ifneq ($(HAS_NATIVE_PLUGINS),)
-    OCAMLOPT_CMXS = $(OCAMLOPT) $(OCAMLOPTFLAGS) -linkall -shared
+    OCAMLOPT_CMXS = $(OCAMLOPT) $(OCAMLOPTFLAGS) -linkall -shared $(patsubst %,-cclib %,$(MP_LIFLAGS))
     OCAMLOPT_TARGETS = $(call OCAMLOPT_TARGETS0,$(1)) $(addsuffix .cmxs, $(1))
   else
     OCAMLOPT_TARGETS = $(call OCAMLOPT_TARGETS0,$(1))


### PR DESCRIPTION
Prior to this patch, observed behavior on macos with gmp and mpfr
installed via brew (into /usr/local/lib) is that building apron fails
with
```
ocamlopt.opt -inline 20 -linkall -shared -I ../apron -I . -o apron.cmxs apron.cmxa
ld: library not found for -lmpfr
```