### PR TITLE
Registering of an exception printer for manager errors

### DIFF
--- a/mlapronidl/manager.idl
+++ b/mlapronidl/manager.idl
@@ -282,6 +282,10 @@ let print_exclog fmt x =\n\
 let print_funopt fmt x =\n\
   Format.fprintf fmt \"{ @[ algorithm = %i;@ timeout = %i;@ max_object_size = %i;@ flag_exact_wanted = %b;@ flag_best_wanted = %b;@] }\"
     x.algorithm x.timeout x.max_object_size x.flag_exact_wanted x.flag_best_wanted\n\
+let () = Printexc.register_printer (function\n\
+    | Error e ->\n\
+        Some (Format.asprintf \"%a\" print_exclog e)\n\
+    | _ -> None )\n\
 ")
 
 quote(MLI,"(** Set / get the global manager used for deserialization *)")


### PR DESCRIPTION
This PR's aim is to replace the message shown when facing a Mangaer error, which is currently:
`Fatal error: exception Apron.Manager.Error(_)`

by a more meaningful message like:

`Fatal error: exception {  exn = Exc_invalid_argument; funid = Funid_bound_dimension;
          msg = unknown variable x in the environment; }`

This is done simply by registering an exception printer (as explained [here](https://ocaml.org/learn/tutorials/error_handling.html#Printing)) for the `Manager.Error` exception.

Disclaimer: i'am familliar with Apron as a user, but not so much as a developper, so i might have overlooked some changes to do. I tested the change locally and it works fine.