### PR TITLE
Fixed a bug preventing build on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,9 @@ mlapronidl/META: mlapronidl/META.in mlapronidl/META.ppl.in
   ifneq ($(HAS_PPL),)
 	cat mlapronidl/META.ppl.in >> $@;
   endif
-	$(SED) -e '/^\s*archive(byte)/ { p; s ) ,plugin) ;}' -i.bak $@;
+	$(SED) -e '/^[[:space:]]*archive(byte)/ { p; s ) ,plugin) ;}' -i.bak $@;
   ifneq ($(HAS_NATIVE_PLUGINS),)
-	$(SED) -e '/^\s*archive(native)/ { p; s ) ,plugin) ;'\
+	$(SED) -e '/^[[:space:]]*archive(native)/ { p; s ) ,plugin) ;'\
 	'            s \.cmxa\" .cmxs\" ;}' -i.bak $@;
   endif
 	test -f $@.bak && rm -f $@.bak


### PR DESCRIPTION
Replaced sed RE element `\s` with the non gnu-sed specific version `[[:space:]]`.
Relevant link: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=253893