### PR TITLE
Fix segmentation fault due to varargs on Apple M1

### DIFF
--- a/apron/ap_abstract0.c
+++ b/apron/ap_abstract0.c
@@ -556,7 +556,7 @@ bool ap_abstract0_check_dimperm(ap_funid_t funid, ap_manager_t* man,
 ap_abstract0_t* ap_abstract0_copy(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_COPY,man,a)){
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
+    void* (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
     return ap_abstract0_cons(man,ptr(man,a->value));
   }
   else {
@@ -589,7 +589,7 @@ void ap_abstract0_free(ap_manager_t* man, ap_abstract0_t* a)
 size_t ap_abstract0_size(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_ASIZE,man,a)){
-    size_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_ASIZE];
+    size_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_ASIZE];
     return ptr(man,a->value);
   }
   else {
@@ -603,21 +603,21 @@ size_t ap_abstract0_size(ap_manager_t* man, ap_abstract0_t* a)
 void ap_abstract0_minimize(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_MINIMIZE,man,a)){
-    void (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_MINIMIZE];
+    void (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_MINIMIZE];
     ptr(man,a->value);
   }
 }
 void ap_abstract0_canonicalize(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_CANONICALIZE,man,a)){
-    void (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_CANONICALIZE];
+    void (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_CANONICALIZE];
     ptr(man,a->value);
   }
 }
 int ap_abstract0_hash(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_CANONICALIZE,man,a)){
-    int (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_HASH];
+    int (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_HASH];
     return ptr(man,a->value);
   }
   else
@@ -626,7 +626,7 @@ int ap_abstract0_hash(ap_manager_t* man, ap_abstract0_t* a)
 void ap_abstract0_approximate(ap_manager_t* man, ap_abstract0_t* a, int n)
 {
   if (ap_abstract0_checkman1(AP_FUNID_APPROXIMATE,man,a)){
-    void (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_APPROXIMATE];
+    void (*ptr)(ap_manager_t*,void*,int) = man->funptr[AP_FUNID_APPROXIMATE];
     ptr(man,a->value,n);
   }
 }
@@ -639,7 +639,7 @@ void ap_abstract0_fprint(FILE* stream, ap_manager_t* man,
 			 char** name_of_dim)
 {
   if (ap_abstract0_checkman1(AP_FUNID_FPRINT,man,a)){
-    void (*ptr)(FILE*,ap_manager_t*,...) = man->funptr[AP_FUNID_FPRINT];
+    void (*ptr)(FILE*,ap_manager_t*,void*,char**) = man->funptr[AP_FUNID_FPRINT];
     ptr(stream,man,a->value,name_of_dim);
   }
   else {
@@ -653,7 +653,7 @@ void ap_abstract0_fprintdiff(FILE* stream, ap_manager_t* man,
 {
   if (ap_abstract0_checkman2(AP_FUNID_FPRINTDIFF,man,a,b) &&
       ap_abstract0_check_abstract2(AP_FUNID_FPRINTDIFF,man,a,b) ){
-    void (*ptr)(FILE*,ap_manager_t*,...) = man->funptr[AP_FUNID_FPRINTDIFF];
+    void (*ptr)(FILE*,ap_manager_t*,void*,void*,char**) = man->funptr[AP_FUNID_FPRINTDIFF];
     ptr(stream,man,a->value,b->value,name_of_dim);
   }
   else {
@@ -663,7 +663,7 @@ void ap_abstract0_fprintdiff(FILE* stream, ap_manager_t* man,
 void ap_abstract0_fdump(FILE* stream, ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_FDUMP,man,a)){
-    void (*ptr)(FILE*,ap_manager_t*,...) = man->funptr[AP_FUNID_FDUMP];
+    void (*ptr)(FILE*,ap_manager_t*,void*) = man->funptr[AP_FUNID_FDUMP];
     ptr(stream,man,a->value);
   }
   else {
@@ -677,7 +677,7 @@ void ap_abstract0_fdump(FILE* stream, ap_manager_t* man, ap_abstract0_t* a)
 ap_membuf_t ap_abstract0_serialize_raw(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_SERIALIZE_RAW,man,a)){
-    ap_membuf_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_SERIALIZE_RAW];
+    ap_membuf_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_SERIALIZE_RAW];
     return ptr(man,a->value);
   }
   else {
@@ -687,7 +687,7 @@ ap_membuf_t ap_abstract0_serialize_raw(ap_manager_t* man, ap_abstract0_t* a)
 }
 ap_abstract0_t* ap_abstract0_deserialize_raw(ap_manager_t* man, void* p, size_t* size)
 {
-  void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_DESERIALIZE_RAW];
+  void* (*ptr)(ap_manager_t*,void*,size_t*) = man->funptr[AP_FUNID_DESERIALIZE_RAW];
   return ap_abstract0_cons(man,ptr(man,p,size));
 }
 
@@ -699,17 +699,17 @@ ap_abstract0_t* ap_abstract0_deserialize_raw(ap_manager_t* man, void* p, size_t*
 /* ============================================================ */
 ap_abstract0_t* ap_abstract0_bottom(ap_manager_t* man, size_t intdim, size_t realdim)
 {
-  void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_BOTTOM];
+  void* (*ptr)(ap_manager_t*,size_t,size_t) = man->funptr[AP_FUNID_BOTTOM];
   return ap_abstract0_cons(man,ptr(man,intdim,realdim));
 }
 ap_abstract0_t* ap_abstract0_top(ap_manager_t* man, size_t intdim, size_t realdim){
-  void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_TOP];
+  void* (*ptr)(ap_manager_t*,size_t,size_t) = man->funptr[AP_FUNID_TOP];
   return ap_abstract0_cons(man,ptr(man,intdim,realdim));
 }
 ap_abstract0_t* ap_abstract0_of_box(ap_manager_t* man,
 				    size_t intdim, size_t realdim,
 				    ap_interval_t** tinterval){
-  void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_OF_BOX];
+  void* (*ptr)(ap_manager_t*,size_t,size_t,ap_interval_t**) = man->funptr[AP_FUNID_OF_BOX];
   return ap_abstract0_cons(man,ptr(man,intdim,realdim,tinterval));
 }
 
@@ -719,7 +719,7 @@ ap_abstract0_t* ap_abstract0_of_box(ap_manager_t* man,
 ap_dimension_t ap_abstract0_dimension(ap_manager_t* man, ap_abstract0_t* a)
 {
   ap_abstract0_checkman1(AP_FUNID_DIMENSION,man,a);
-  ap_dimension_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_DIMENSION];
+  ap_dimension_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_DIMENSION];
   return ptr(a->man,a->value);
 }
 
@@ -729,7 +729,7 @@ ap_dimension_t ap_abstract0_dimension(ap_manager_t* man, ap_abstract0_t* a)
 bool ap_abstract0_is_bottom(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_IS_BOTTOM,man,a)){
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+    bool (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
     return ptr(man,a->value);
   }
   else {
@@ -740,7 +740,7 @@ bool ap_abstract0_is_bottom(ap_manager_t* man, ap_abstract0_t* a)
 bool ap_abstract0_is_top(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_IS_TOP,man,a)){
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_TOP];
+    bool (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_TOP];
     return ptr(man,a->value);
   }
   else {
@@ -756,7 +756,7 @@ bool ap_abstract0_is_leq(ap_manager_t* man, ap_abstract0_t* a1, ap_abstract0_t* 
   else if (ap_abstract0_checkman2(AP_FUNID_IS_LEQ,man,a1,a2) &&
 	   ap_abstract0_check_abstract2(AP_FUNID_IS_LEQ,man,a1,a2)){
     if (a1->value==a2->value) return true;
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_LEQ];
+    bool (*ptr)(ap_manager_t*,void*,void*) = man->funptr[AP_FUNID_IS_LEQ];
     return ptr(man,a1->value,a2->value);
   }
   else {
@@ -772,7 +772,7 @@ bool ap_abstract0_is_eq(ap_manager_t* man, ap_abstract0_t* a1, ap_abstract0_t* a
   if (ap_abstract0_checkman2(AP_FUNID_IS_EQ,man,a1,a2) &&
       ap_abstract0_check_abstract2(AP_FUNID_IS_EQ,man,a1,a2)){
     if (a1->value==a2->value) return true;
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_EQ];
+    bool (*ptr)(ap_manager_t*,void*,void*) = man->funptr[AP_FUNID_IS_EQ];
     return ptr(man,a1->value,a2->value);
   }
   else {
@@ -784,7 +784,7 @@ bool ap_abstract0_sat_lincons(ap_manager_t* man, ap_abstract0_t* a, ap_lincons0_
 {
   if (ap_abstract0_checkman1(AP_FUNID_SAT_LINCONS,man,a) &&
       ap_abstract0_check_linexpr(AP_FUNID_SAT_LINCONS,man,_ap_abstract0_dimension(a),lincons->linexpr0) ){
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_SAT_LINCONS];
+    bool (*ptr)(ap_manager_t*,void*,ap_lincons0_t*) = man->funptr[AP_FUNID_SAT_LINCONS];
     return ptr(man,a->value,lincons);
   }
   else {
@@ -796,7 +796,7 @@ bool ap_abstract0_sat_tcons(ap_manager_t* man, ap_abstract0_t* a, ap_tcons0_t* t
 {
   if (ap_abstract0_checkman1(AP_FUNID_SAT_TCONS,man,a) &&
       ap_abstract0_check_texpr(AP_FUNID_SAT_TCONS,man,_ap_abstract0_dimension(a),tcons->texpr0) ){
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_SAT_TCONS];
+    bool (*ptr)(ap_manager_t*,void*,ap_tcons0_t*) = man->funptr[AP_FUNID_SAT_TCONS];
     return ptr(man,a->value,tcons);
   }
   else {
@@ -809,7 +809,7 @@ bool ap_abstract0_sat_interval(ap_manager_t* man, ap_abstract0_t* a,
 {
   if (ap_abstract0_checkman1(AP_FUNID_SAT_INTERVAL,man,a) &&
       ap_abstract0_check_dim(AP_FUNID_SAT_INTERVAL,man,_ap_abstract0_dimension(a),dim)){
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_SAT_INTERVAL];
+    bool (*ptr)(ap_manager_t*,void*,ap_dim_t,ap_interval_t*) = man->funptr[AP_FUNID_SAT_INTERVAL];
     return ptr(man,a->value,dim,interval);
   }
   else {
@@ -822,7 +822,7 @@ bool ap_abstract0_is_dimension_unconstrained(ap_manager_t* man, ap_abstract0_t* 
 {
   if (ap_abstract0_checkman1(AP_FUNID_IS_DIMENSION_UNCONSTRAINED,man,a) &&
       ap_abstract0_check_dim(AP_FUNID_IS_DIMENSION_UNCONSTRAINED,man,_ap_abstract0_dimension(a),dim)){
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_DIMENSION_UNCONSTRAINED];
+    bool (*ptr)(ap_manager_t*,void*,ap_dim_t) = man->funptr[AP_FUNID_IS_DIMENSION_UNCONSTRAINED];
     return ptr(man,a->value,dim);
   }
   else {
@@ -839,7 +839,7 @@ ap_interval_t* ap_abstract0_bound_linexpr(ap_manager_t* man,
 {
   if (ap_abstract0_checkman1(AP_FUNID_BOUND_LINEXPR,man,a) &&
       ap_abstract0_check_linexpr(AP_FUNID_BOUND_LINEXPR,man,_ap_abstract0_dimension(a),expr)){
-    ap_interval_t* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_BOUND_LINEXPR];
+    ap_interval_t* (*ptr)(ap_manager_t*,void*,ap_linexpr0_t*) = man->funptr[AP_FUNID_BOUND_LINEXPR];
     return ptr(man,a->value,expr);
   }
   else {
@@ -854,7 +854,7 @@ ap_interval_t* ap_abstract0_bound_texpr(ap_manager_t* man,
 {
   if (ap_abstract0_checkman1(AP_FUNID_BOUND_TEXPR,man,a) &&
       ap_abstract0_check_texpr(AP_FUNID_BOUND_TEXPR,man,_ap_abstract0_dimension(a),expr)){
-    ap_interval_t* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_BOUND_TEXPR];
+    ap_interval_t* (*ptr)(ap_manager_t*,void*,ap_texpr0_t*) = man->funptr[AP_FUNID_BOUND_TEXPR];
     return ptr(man,a->value,expr);
   }
   else {
@@ -869,7 +869,7 @@ ap_interval_t* ap_abstract0_bound_dimension(ap_manager_t* man,
 {
   if (ap_abstract0_checkman1(AP_FUNID_BOUND_DIMENSION,man,a) &&
       ap_abstract0_check_dim(AP_FUNID_BOUND_DIMENSION,man,_ap_abstract0_dimension(a),dim)){
-    ap_interval_t* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_BOUND_DIMENSION];
+    ap_interval_t* (*ptr)(ap_manager_t*,void*,ap_dim_t) = man->funptr[AP_FUNID_BOUND_DIMENSION];
     return ptr(man,a->value,dim);
   }
   else {
@@ -882,7 +882,7 @@ ap_interval_t* ap_abstract0_bound_dimension(ap_manager_t* man,
 ap_lincons0_array_t ap_abstract0_to_lincons_array(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_TO_LINCONS_ARRAY,man,a)){
-    ap_lincons0_array_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
+    ap_lincons0_array_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
     return ptr(man,a->value);
   }
   else {
@@ -893,7 +893,7 @@ ap_lincons0_array_t ap_abstract0_to_lincons_array(ap_manager_t* man, ap_abstract
 ap_tcons0_array_t ap_abstract0_to_tcons_array(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_TO_TCONS_ARRAY,man,a)){
-    ap_tcons0_array_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_TO_TCONS_ARRAY];
+    ap_tcons0_array_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_TO_TCONS_ARRAY];
     return ptr(man,a->value);
   }
   else {
@@ -904,7 +904,7 @@ ap_tcons0_array_t ap_abstract0_to_tcons_array(ap_manager_t* man, ap_abstract0_t*
 ap_interval_t** ap_abstract0_to_box(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_TO_BOX,man,a)){
-    ap_interval_t** (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_TO_BOX];
+    ap_interval_t** (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_TO_BOX];
     return ptr(man,a->value);
   }
   else {
@@ -921,7 +921,7 @@ ap_interval_t** ap_abstract0_to_box(ap_manager_t* man, ap_abstract0_t* a)
 ap_generator0_array_t ap_abstract0_to_generator_array(ap_manager_t* man, ap_abstract0_t* a)
 {
   if (ap_abstract0_checkman1(AP_FUNID_TO_GENERATOR_ARRAY,man,a)){
-    ap_generator0_array_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_TO_GENERATOR_ARRAY];
+    ap_generator0_array_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_TO_GENERATOR_ARRAY];
     return ptr(man,a->value);
   }
   else {
@@ -942,7 +942,7 @@ ap_abstract0_t* ap_abstract0_meetjoin(ap_funid_t funid,
 {
   if (ap_abstract0_checkman2(funid,man,a1,a2) &&
       ap_abstract0_check_abstract2(funid,man,a1,a2)){
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[funid];
+    void* (*ptr)(ap_manager_t*,bool,void*,void*) = man->funptr[funid];
     void* value = ptr(man,destructive,a1->value,a2->value);
     return ap_abstract0_cons2(man,destructive,a1,value);
   }
@@ -967,7 +967,7 @@ ap_abstract0_t* ap_abstract0_meetjoin_array(ap_funid_t funid, ap_manager_t* man,
       ap_abstract0_check_abstract_array(funid,man,tab,size)){
     size_t i;
     ap_abstract0_t* res;
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[funid];
+    void* (*ptr)(ap_manager_t*,void**,size_t) = man->funptr[funid];
     void** ntab = malloc(size*sizeof(void*));
     for (i=0;i<size;i++) ntab[i] = tab[i]->value;
     res = ap_abstract0_cons(man,ptr(man,ntab,size));
@@ -998,7 +998,7 @@ ap_abstract0_t* ap_abstract0_meet_lincons_array(ap_manager_t* man,
   ap_dimension_t dimension = _ap_abstract0_dimension(a);
   if (ap_abstract0_checkman1(AP_FUNID_MEET_LINCONS_ARRAY,man,a) &&
       ap_abstract0_check_lincons_array(AP_FUNID_MEET_LINCONS_ARRAY,man,dimension,array) ){
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_MEET_LINCONS_ARRAY];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_lincons0_array_t*) = man->funptr[AP_FUNID_MEET_LINCONS_ARRAY];
     void* value = ptr(man,destructive,a->value,array);
     return ap_abstract0_cons2(man,destructive,a,value);
   }
@@ -1017,7 +1017,7 @@ ap_abstract0_t* ap_abstract0_meet_tcons_array(ap_manager_t* man,
   ap_dimension_t dimension = _ap_abstract0_dimension(a);
   if (ap_abstract0_checkman1(AP_FUNID_MEET_TCONS_ARRAY,man,a) &&
       ap_abstract0_check_tcons_array(AP_FUNID_MEET_TCONS_ARRAY,man,dimension,array) ){
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_MEET_TCONS_ARRAY];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_tcons0_array_t*) = man->funptr[AP_FUNID_MEET_TCONS_ARRAY];
     void* value = ptr(man,destructive,a->value,array);
     return ap_abstract0_cons2(man,destructive,a,value);
   }
@@ -1036,7 +1036,7 @@ ap_abstract0_t* ap_abstract0_add_ray_array(ap_manager_t* man,
   ap_dimension_t dimension = _ap_abstract0_dimension(a);
   if (ap_abstract0_checkman1(AP_FUNID_ADD_RAY_ARRAY,man,a) &&
       ap_abstract0_check_generator_array(AP_FUNID_ADD_RAY_ARRAY,man,dimension,array)){
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_ADD_RAY_ARRAY];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_generator0_array_t*) = man->funptr[AP_FUNID_ADD_RAY_ARRAY];
     void* value = ptr(man,destructive,a->value,array);
     return ap_abstract0_cons2(man,destructive,a,value);
   }
@@ -1078,7 +1078,7 @@ ap_abstract0_t* ap_abstract0_asssub_linexpr_array(ap_funid_t funid,
 	(dest!=NULL ? (ap_abstract0_checkman1(funid,man,dest) && ap_abstract0_check_abstract2(funid,man,a,dest)) : true) &&
 	ap_abstract0_check_dim_array(funid,man,dimension,tdim,size) &&
 	ap_abstract0_check_linexpr_array(funid,man,dimension,texpr,size) ){
-      void* (*ptr)(ap_manager_t*,...) = man->funptr[funid];
+      void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t*,ap_linexpr0_t**,size_t,void*) = man->funptr[funid];
       void* value = ptr(man,destructive,a->value,tdim,texpr,size,dest ? dest->value : NULL);
       return ap_abstract0_cons2(man,destructive,a,value);
     }
@@ -1138,7 +1138,7 @@ ap_abstract0_t* ap_abstract0_asssub_texpr_array(ap_funid_t funid,
 	(dest!=NULL ? (ap_abstract0_checkman1(funid,man,dest) && ap_abstract0_check_abstract2(funid,man,a,dest)) : true) &&
 	ap_abstract0_check_dim_array(funid,man,dimension,tdim,size) &&
 	ap_abstract0_check_texpr_array(funid,man,dimension,texpr,size) ){
-      void* (*ptr)(ap_manager_t*,...) = man->funptr[funid];
+      void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t*,ap_texpr0_t**,size_t,void*) = man->funptr[funid];
       void* value = ptr(man,destructive,a->value,tdim,texpr,size,dest ? dest->value : NULL);
       return ap_abstract0_cons2(man,destructive,a,value);
     }
@@ -1195,7 +1195,7 @@ ap_abstract0_t* ap_abstract0_forget_array(ap_manager_t* man,
     ap_dimension_t dimension = _ap_abstract0_dimension(a);
     if (ap_abstract0_checkman1(AP_FUNID_FORGET_ARRAY,man,a) &&
 	ap_abstract0_check_dim_array(AP_FUNID_FORGET_ARRAY,man,dimension,tdim,size)){
-      void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_FORGET_ARRAY];
+      void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t*,size_t,bool) = man->funptr[AP_FUNID_FORGET_ARRAY];
       void* value = ptr(man,destructive,a->value,tdim,size,project);
       return ap_abstract0_cons2(man,destructive,a,value);
     }
@@ -1230,7 +1230,7 @@ ap_abstract0_t* ap_abstract0_add_dimensions(ap_manager_t* man,
     ap_dimension_t dimension = _ap_abstract0_dimension(a);
     if (ap_abstract0_checkman1(AP_FUNID_ADD_DIMENSIONS,man,a) &&
 	ap_abstract0_check_ap_dimchange_add(AP_FUNID_ADD_DIMENSIONS,man,dimension,dimchange)){
-      void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
+      void* (*ptr)(ap_manager_t*,bool,void*,ap_dimchange_t*,bool) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
       void* value = ptr(man,destructive,a->value,dimchange,project);
       return ap_abstract0_cons2(man,destructive,a,value);
     }
@@ -1259,7 +1259,7 @@ ap_abstract0_t* ap_abstract0_remove_dimensions(ap_manager_t* man,
     ap_dimension_t dimension = _ap_abstract0_dimension(a);
     if (ap_abstract0_checkman1(AP_FUNID_REMOVE_DIMENSIONS,man,a) &&
 	ap_abstract0_check_ap_dimchange_remove(AP_FUNID_REMOVE_DIMENSIONS,man,dimension,dimchange)){
-      void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
+      void* (*ptr)(ap_manager_t*,bool,void*,ap_dimchange_t*) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
       void* value = ptr(man,destructive,a->value,dimchange);
       return ap_abstract0_cons2(man,destructive,a,value);
     }
@@ -1279,7 +1279,7 @@ ap_abstract0_t* ap_abstract0_permute_dimensions(ap_manager_t* man,
   ap_dimension_t dimension = _ap_abstract0_dimension(a);
   if (ap_abstract0_checkman1(AP_FUNID_PERMUTE_DIMENSIONS,man,a) &&
       ap_abstract0_check_dimperm(AP_FUNID_PERMUTE_DIMENSIONS,man,dimension,perm)){
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_dimperm_t*) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
     void* value = ptr(man,destructive,a->value,perm);
     return ap_abstract0_cons2(man,destructive,a,value);
   }
@@ -1312,7 +1312,7 @@ ap_abstract0_t* ap_abstract0_expand(ap_manager_t* man,
     ap_dimension_t dimension = _ap_abstract0_dimension(a);
     if (ap_abstract0_checkman1(AP_FUNID_EXPAND,man,a) &&
 	ap_abstract0_check_dim(AP_FUNID_EXPAND,man,dimension,dim)){
-      void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_EXPAND];
+      void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t,size_t) = man->funptr[AP_FUNID_EXPAND];
       void* value = ptr(man,destructive,a->value,dim,n);
       return ap_abstract0_cons2(man,destructive,a,value);
     }
@@ -1365,12 +1365,12 @@ ap_abstract0_t* ap_abstract0_fold(ap_manager_t* man,
 	return a;
       }
       else {
-	void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
+	void* (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
 	return ap_abstract0_cons(man,ptr(man,a->value));
       }
     }
     else {
-      void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_FOLD];
+      void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t*,size_t) = man->funptr[AP_FUNID_FOLD];
       void* value = ptr(man,destructive,a->value,tdim,size);
       return ap_abstract0_cons2(man,destructive,a,value);
     }
@@ -1391,7 +1391,7 @@ ap_abstract0_t* ap_abstract0_widening(ap_manager_t* man,
 {
   if (ap_abstract0_checkman2(AP_FUNID_WIDENING,man,a1,a2) &&
       ap_abstract0_check_abstract2(AP_FUNID_WIDENING,man,a1,a2)){
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_WIDENING];
+    void* (*ptr)(ap_manager_t*,void*,void*) = man->funptr[AP_FUNID_WIDENING];
     void* value = ptr(man,a1->value,a2->value);
     return ap_abstract0_cons(man,value);
   }
@@ -1410,7 +1410,7 @@ ap_abstract0_t* ap_abstract0_closure(ap_manager_t* man, bool destructive, ap_abs
 {
   ap_dimension_t dimension = _ap_abstract0_dimension(a);
   if (ap_abstract0_checkman1(AP_FUNID_CLOSURE,man,a)){
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_CLOSURE];
+    void* (*ptr)(ap_manager_t*,bool,void*) = man->funptr[AP_FUNID_CLOSURE];
     void* value = ptr(man,destructive,a->value);
     return ap_abstract0_cons2(man,destructive,a,value);
   }
@@ -1523,8 +1523,8 @@ ap_abstract0_t* ap_abstract0_widening_threshold(ap_manager_t* man,
 						ap_abstract0_t* a2,
 						ap_lincons0_array_t* array)
 {
-  void* (*ptr)(ap_manager_t*,...);
-  bool (*ptr2)(ap_manager_t*,...);
+  void* (*ptr)(ap_manager_t*,void*,void*);
+  bool (*ptr2)(ap_manager_t*,void*,ap_lincons0_t*);
   void* value;
   size_t i,j,size;
   ap_lincons0_t tmp;
@@ -1551,6 +1551,7 @@ ap_abstract0_t* ap_abstract0_widening_threshold(ap_manager_t* man,
       }
     }
     if (i>0){
+      void* (*ptr)(ap_manager_t*,bool,void*,ap_lincons0_array_t*);
       array->size = i;
       ptr = man->funptr[AP_FUNID_MEET_LINCONS_ARRAY];
       value = ptr(man,true,value,array);

--- a/apron/ap_abstract0.h
+++ b/apron/ap_abstract0.h
@@ -516,7 +516,7 @@ bool ap_abstract0_checkman_array(ap_funid_t funid,
 static inline
 ap_dimension_t _ap_abstract0_dimension(ap_abstract0_t* a)
 {
-  ap_dimension_t (*ptr)(ap_manager_t*,...) = (ap_dimension_t (*) (ap_manager_t*,...))(a->man->funptr[AP_FUNID_DIMENSION]);
+  ap_dimension_t (*ptr)(ap_manager_t*, void*) = (ap_dimension_t (*) (ap_manager_t*, void*))(a->man->funptr[AP_FUNID_DIMENSION]);
   return ptr(a->man,a->value);
 }
 

--- a/apron/ap_abstract1.c
+++ b/apron/ap_abstract1.c
@@ -669,7 +669,7 @@ ap_abstract1_t ap_abstract1_meetjoin_array(ap_funid_t funid, ap_manager_t* man, 
       ap_abstract1_check_env_array(funid,man,tab,size)){
     size_t i;
     ap_abstract0_t* res0;
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[funid];
+    void* (*ptr)(ap_manager_t*,void**,size_t) = man->funptr[funid];
     void** ntab = malloc(size*sizeof(void*));
     for (i=0;i<size;i++) ntab[i] = tab[i].abstract0->value;
     res0 = malloc(sizeof(ap_abstract0_t));

--- a/apron/ap_disjunction.c
+++ b/apron/ap_disjunction.c
@@ -33,7 +33,7 @@ static void ap_disjunction_clear(ap_disjunction_internal_t* intern,
 {
   size_t i;
   ap_manager_t* man = intern->manager;
-  void (*absfree)(ap_manager_t*, ...) = man->funptr[AP_FUNID_FREE];
+  void (*absfree)(ap_manager_t*, void*) = man->funptr[AP_FUNID_FREE];
   for (i=0; i < a->size; i++) {
     if (a->p[i]!=NULL){
       absfree(man, a->p[i]);
@@ -106,9 +106,9 @@ static void ap_disjunction_null_bottom_top(
     bool* const notbottom)
 {
   ap_manager_t* man = intern->manager;
-  void (*free)(ap_manager_t*, ...) = man->funptr[AP_FUNID_FREE];
-  bool (*is_bottom)(ap_manager_t*, ...) = man->funptr[AP_FUNID_IS_BOTTOM];
-  bool (*is_top)(ap_manager_t*, ...) = man->funptr[AP_FUNID_IS_TOP];
+  void (*free)(ap_manager_t*, void*) = man->funptr[AP_FUNID_FREE];
+  bool (*is_bottom)(ap_manager_t*, void*) = man->funptr[AP_FUNID_IS_BOTTOM];
+  bool (*is_top)(ap_manager_t*, void*) = man->funptr[AP_FUNID_IS_TOP];
 
   int bottom = -1;
   *top = -1;
@@ -142,8 +142,8 @@ static void ap_disjunction_elim_redundant(ap_disjunction_internal_t* intern,
 					  ap_disjunction_t* a)
 {
   ap_manager_t* man = intern->manager;
-  void (*free)(ap_manager_t*, ...) = man->funptr[AP_FUNID_FREE];
-  bool (*is_eq)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_EQ];
+  void (*free)(ap_manager_t*, void*) = man->funptr[AP_FUNID_FREE];
+  bool (*is_eq)(ap_manager_t*,void*,void*) = man->funptr[AP_FUNID_IS_EQ];
   int top;
   bool notbottom;
 
@@ -187,7 +187,7 @@ ap_disjunction_t* ap_disjunction_copy(ap_manager_t* manager,
   size_t i;
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
-  void* (*copy)(ap_manager_t*, ...) = man->funptr[AP_FUNID_COPY];
+  void* (*copy)(ap_manager_t*, void*) = man->funptr[AP_FUNID_COPY];
 
   ap_disjunction_t* res = ap_disjunction_alloc(a->size);
   for (i = 0; i < a->size; i++) {
@@ -202,7 +202,7 @@ size_t ap_disjunction_size(ap_manager_t* manager,
   size_t i,res;
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
-  size_t (*size)(ap_manager_t*, ...) = man->funptr[AP_FUNID_ASIZE];
+  size_t (*size)(ap_manager_t*, void*) = man->funptr[AP_FUNID_ASIZE];
 
   res = 0;
   for (i = 0; i < a->size; i++) {
@@ -217,7 +217,7 @@ void ap_disjunction_minimize(ap_manager_t* manager,
   size_t i;
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
-  void* (*minimize)(ap_manager_t*, ...) = man->funptr[AP_FUNID_MINIMIZE];
+  void* (*minimize)(ap_manager_t*, void*) = man->funptr[AP_FUNID_MINIMIZE];
 
   ap_disjunction_elim_redundant(intern,a);
   for (i = 0; i < a->size; i++) {
@@ -230,7 +230,7 @@ void ap_disjunction_canonicalize(ap_manager_t* manager,
   size_t i;
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
-  void* (*canonicalize)(ap_manager_t*, ...) = man->funptr[AP_FUNID_CANONICALIZE];
+  void* (*canonicalize)(ap_manager_t*, void*) = man->funptr[AP_FUNID_CANONICALIZE];
   ap_disjunction_elim_redundant(intern,a);
   for (i = 0; i < a->size; i++) {
     canonicalize(man, a->p[i]);
@@ -264,7 +264,7 @@ void ap_disjunction_fprint(FILE* stream, ap_manager_t* manager,
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  void (*ptr)(FILE* stream, ap_manager_t*,...) = man->funptr[AP_FUNID_FPRINT];
+  void (*ptr)(FILE* stream, ap_manager_t*,void*,char**) = man->funptr[AP_FUNID_FPRINT];
 
   fprintf(stream,"disjunction of library %s\n",man->library);
 
@@ -289,7 +289,7 @@ void ap_disjunction_fdump(FILE* stream, ap_manager_t* manager,
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  void (*ptr)(FILE* stream, ap_manager_t*,...) = man->funptr[AP_FUNID_FDUMP];
+  void (*ptr)(FILE* stream, ap_manager_t*,void*) = man->funptr[AP_FUNID_FDUMP];
 
   fprintf(stream,"disjunction of library %s\n",man->library);
 
@@ -318,7 +318,7 @@ static ap_disjunction_t* ap_disjunction_of_one(void* abs)
   {									\
     ap_disjunction_internal_t* intern = get_internal(manager);	\
     ap_manager_t* man = intern->manager;				\
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[FUNID];		\
+    void* (*ptr)(ap_manager_t*,size_t,size_t) = man->funptr[FUNID];		\
     void* abs = ptr(man,intdim,realdim);				\
 									\
     return ap_disjunction_of_one(abs);					\
@@ -335,7 +335,7 @@ ap_disjunction_t* ap_disjunction_of_box(ap_manager_t* manager,
   void* abs;
 
   ap_manager_t* man = intern->manager;
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_OF_BOX];
+  void* (*ptr)(ap_manager_t*, size_t,size_t,ap_interval_t**) = man->funptr[AP_FUNID_OF_BOX];
   abs = ptr(man, intdim, realdim, tinterval);
   return ap_disjunction_of_one(abs);
 }
@@ -345,7 +345,7 @@ ap_dimension_t ap_disjunction_dimension(ap_manager_t* manager,
 {
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
-  ap_dimension_t (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_DIMENSION];
+  ap_dimension_t (*ptr)(ap_manager_t*, void*) = man->funptr[AP_FUNID_DIMENSION];
   return ptr(man, a->p[0]);
 }
 
@@ -358,7 +358,7 @@ bool ap_disjunction_is_bottom(ap_manager_t* manager, ap_disjunction_t* a)
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  bool (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_IS_BOTTOM];
+  bool (*ptr)(ap_manager_t*, void*) = man->funptr[AP_FUNID_IS_BOTTOM];
 
   return a->size==1 && ptr(man,a->p[0]);
 }
@@ -368,7 +368,7 @@ bool ap_disjunction_is_top(ap_manager_t* manager, ap_disjunction_t* a)
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  bool (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_IS_TOP];
+  bool (*ptr)(ap_manager_t*, void*) = man->funptr[AP_FUNID_IS_TOP];
 
   return a->size==1 && ptr(man,a->p[0]);
 }
@@ -454,7 +454,7 @@ bool ap_disjunction_sat_lincons(ap_manager_t* manager, ap_disjunction_t* a,
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  bool (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_SAT_LINCONS];
+  bool (*ptr)(ap_manager_t*, void*, ap_lincons0_t*) = man->funptr[AP_FUNID_SAT_LINCONS];
 
   size_t i;
   bool res = true;
@@ -472,7 +472,7 @@ bool ap_disjunction_sat_tcons(ap_manager_t* manager, ap_disjunction_t* a,
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  bool (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_SAT_TCONS];
+  bool (*ptr)(ap_manager_t*, void*, ap_tcons0_t*) = man->funptr[AP_FUNID_SAT_TCONS];
 
   size_t i;
   bool res = true;
@@ -490,7 +490,7 @@ bool ap_disjunction_sat_interval(ap_manager_t* manager, ap_disjunction_t* a,
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  bool (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_SAT_INTERVAL];
+  bool (*ptr)(ap_manager_t*, void*, ap_dim_t, ap_interval_t*) = man->funptr[AP_FUNID_SAT_INTERVAL];
 
   size_t i;
   bool res = true;
@@ -521,7 +521,7 @@ ap_interval_t* ap_disjunction_bound_linexpr(
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  ap_interval_t* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_BOUND_LINEXPR];
+  ap_interval_t* (*ptr)(ap_manager_t*, void*, ap_linexpr0_t*) = man->funptr[AP_FUNID_BOUND_LINEXPR];
 
   ap_interval_t* gres = ap_interval_alloc();
   ap_interval_set_bottom(gres);
@@ -546,7 +546,7 @@ ap_interval_t* ap_disjunction_bound_texpr(
   ap_interval_t* gres = ap_interval_alloc();
   ap_interval_set_bottom(gres);
 
-  ap_interval_t* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_BOUND_TEXPR];
+  ap_interval_t* (*ptr)(ap_manager_t*, void*, ap_texpr0_t*) = man->funptr[AP_FUNID_BOUND_TEXPR];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -568,7 +568,7 @@ ap_interval_t* ap_disjunction_bound_dimension(ap_manager_t* manager,
   ap_interval_t* gres = ap_interval_alloc();
   ap_interval_set_bottom(gres);
 
-  ap_interval_t* (*ptr)(ap_manager_t*, ...) =	man->funptr[AP_FUNID_BOUND_DIMENSION];
+  ap_interval_t* (*ptr)(ap_manager_t*, void*, ap_dim_t) =	man->funptr[AP_FUNID_BOUND_DIMENSION];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -593,7 +593,7 @@ ap_lincons0_array_t ap_disjunction_to_lincons_array(ap_manager_t* manager,
   ap_lincons0_array_t garray;
 
   if (a->size==1){
-    ap_lincons0_array_t (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
+    ap_lincons0_array_t (*ptr)(ap_manager_t*, void*) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
     garray = ptr(man,a->p[0]);
   }
   else {
@@ -626,7 +626,7 @@ ap_lincons0_array_t ap_disjunction_to_lincons0_set(ap_manager_t* manager,
   garray.p = NULL;
   garray.size = 0;
 
-  ap_lincons0_array_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
+  ap_lincons0_array_t (*ptr)(ap_manager_t*, void*) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
 
   size_t i,j;
   for (i=0;i<a->size;i++){
@@ -656,8 +656,8 @@ ap_interval_t** ap_disjunction_to_box(ap_manager_t* manager,
   ap_interval_t** gbox = NULL;
   size_t nbdims = 0;
 
-  ap_interval_t** (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_TO_BOX];
-  ap_dimension_t (*ptrdimension)(ap_manager_t*, ...) = man->funptr[AP_FUNID_DIMENSION];
+  ap_interval_t** (*ptr)(ap_manager_t*, void*) = man->funptr[AP_FUNID_TO_BOX];
+  ap_dimension_t (*ptrdimension)(ap_manager_t*, void*) = man->funptr[AP_FUNID_DIMENSION];
   ap_dimension_t dimension = ptrdimension(man, a->p[0]);
   nbdims = dimension.intdim + dimension.realdim;
 
@@ -727,7 +727,7 @@ ap_disjunction_t* ap_disjunction_join(ap_manager_t* manager,
 
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
-  void* (*copy)(ap_manager_t*, ...) = man->funptr[AP_FUNID_COPY];
+  void* (*copy)(ap_manager_t*, void*) = man->funptr[AP_FUNID_COPY];
   ap_disjunction_t* res = ap_disjunction_alloc(a1->size+a2->size);
   size_t i,j;
   for (i=0; i<a1->size; i++){
@@ -766,7 +766,7 @@ ap_disjunction_t* ap_disjunction_join_array(ap_manager_t* manager,
   else {
     ap_disjunction_internal_t* intern = get_internal(manager);
     ap_manager_t* man = intern->manager;
-    void* (*copy)(ap_manager_t*, ...) = man->funptr[AP_FUNID_COPY];
+    void* (*copy)(ap_manager_t*, void*) = man->funptr[AP_FUNID_COPY];
 
     size_t length,i,j,l;
     ap_disjunction_t* res;
@@ -823,8 +823,8 @@ ap_disjunction_t* ap_disjunction_meet(ap_manager_t* manager, bool destructive,
 
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
-  void* (*meet)(ap_manager_t*, ...) = man->funptr[AP_FUNID_MEET];
-  void* (*is_bottom)(ap_manager_t*, ...) = man->funptr[AP_FUNID_IS_BOTTOM];
+  void* (*meet)(ap_manager_t*, bool, void*, void*) = man->funptr[AP_FUNID_MEET];
+  void* (*is_bottom)(ap_manager_t*, void*) = man->funptr[AP_FUNID_IS_BOTTOM];
 
   ap_disjunction_elim_redundant(intern, a1);
   ap_disjunction_elim_redundant(intern, a2);
@@ -877,7 +877,7 @@ ap_disjunction_t* ap_disjunction_meet_lincons_array(ap_manager_t* manager,
 
   ap_disjunction_t* res = destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_MEET_LINCONS_ARRAY];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_lincons0_array_t*) = man->funptr[AP_FUNID_MEET_LINCONS_ARRAY];
 
   int top;
   bool notbottom;
@@ -898,7 +898,7 @@ ap_disjunction_t* ap_disjunction_meet_tcons_array(ap_manager_t* manager,bool des
 
   ap_disjunction_t* res= destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_MEET_TCONS_ARRAY];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_tcons0_array_t*) = man->funptr[AP_FUNID_MEET_TCONS_ARRAY];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -923,7 +923,7 @@ ap_disjunction_t* ap_disjunction_add_ray_array(ap_manager_t* manager,
 
   ap_disjunction_t* res= destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_ADD_RAY_ARRAY];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_lincons0_array_t*) = man->funptr[AP_FUNID_ADD_RAY_ARRAY];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -954,8 +954,8 @@ ap_disjunction_t* ap_disjunction_asssub_linexpr_array(
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[funid];
-  bool (*is_bottom)(ap_manager_t*, ...) =	man->funptr[AP_FUNID_IS_BOTTOM];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_dim_t*, ap_linexpr0_t**, size_t, void*) = man->funptr[funid];
+  bool (*is_bottom)(ap_manager_t*, void*) =	man->funptr[AP_FUNID_IS_BOTTOM];
 
   if (dest!=NULL){
     ap_manager_raise_exception(manager, AP_EXC_NOT_IMPLEMENTED, funid, "assign or substitute supported only when dest==NULL");
@@ -997,8 +997,8 @@ ap_disjunction_t* ap_disjunction_asssub_texpr_array(
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[funid];
-  bool (*is_bottom)(ap_manager_t*, ...) =	man->funptr[AP_FUNID_IS_BOTTOM];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_dim_t*, ap_texpr0_t**, size_t, void*) = man->funptr[funid];
+  bool (*is_bottom)(ap_manager_t*, void*) =	man->funptr[AP_FUNID_IS_BOTTOM];
 
   if (dest!=NULL){
     ap_manager_raise_exception(manager, AP_EXC_NOT_IMPLEMENTED, funid, "assign or substitute supported only when dest==NULL");
@@ -1043,7 +1043,7 @@ ap_disjunction_t* ap_disjunction_forget_array(
 
   ap_disjunction_t* res= destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_FORGET_ARRAY];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_dim_t*, size_t, bool) = man->funptr[AP_FUNID_FORGET_ARRAY];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -1071,7 +1071,7 @@ ap_disjunction_t* ap_disjunction_add_dimensions(
   ap_manager_t* man = intern->manager;
   ap_disjunction_t* res = destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_dimchange_t*, bool) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -1088,7 +1088,7 @@ ap_disjunction_t* ap_disjunction_remove_dimensions(ap_manager_t* manager,
 
   ap_disjunction_t* res = destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_dimchange_t*) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -1114,7 +1114,7 @@ ap_disjunction_t* ap_disjunction_permute_dimensions(ap_manager_t* manager,
 
   ap_disjunction_t* res= destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_dimperm_t*) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -1140,7 +1140,7 @@ ap_disjunction_t* ap_disjunction_expand(ap_manager_t* manager,
 
   ap_disjunction_t* res = destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_EXPAND];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_dim_t, size_t) = man->funptr[AP_FUNID_EXPAND];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -1162,7 +1162,7 @@ ap_disjunction_t* ap_disjunction_fold(ap_manager_t* manager,
 
   ap_disjunction_t* res = destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_FOLD];
+  void* (*ptr)(ap_manager_t*, bool, void*, ap_dim_t*, size_t) = man->funptr[AP_FUNID_FOLD];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -1199,7 +1199,7 @@ ap_disjunction_t* ap_disjunction_closure(ap_manager_t* manager,
 
   ap_disjunction_t* res = destructive ? a : ap_disjunction_alloc(a->size);
 
-  void* (*ptr)(ap_manager_t*, ...) = man->funptr[AP_FUNID_CLOSURE];
+  void* (*ptr)(ap_manager_t*, bool, void*) = man->funptr[AP_FUNID_CLOSURE];
 
   size_t i;
   for (i = 0; i < a->size; i++) {
@@ -1346,7 +1346,7 @@ void** ap_disjunction_decompose(ap_manager_t* manager, bool destructive,
   ap_disjunction_internal_t* intern = get_internal(manager);
   ap_manager_t* man = intern->manager;
 
-  void* (*copy)(ap_manager_t*, ...) = man->funptr[AP_FUNID_COPY];
+  void* (*copy)(ap_manager_t*, void*) = man->funptr[AP_FUNID_COPY];
 
   *psize = a->size;
 
@@ -1375,7 +1375,7 @@ ap_disjunction_t* ap_disjunction_compose(ap_manager_t* manager,
 
   ap_disjunction_t* res = ap_disjunction_alloc(size);
 
-  void* (*copy)(ap_manager_t*, ...) = man->funptr[AP_FUNID_COPY];
+  void* (*copy)(ap_manager_t*, void*) = man->funptr[AP_FUNID_COPY];
 
   size_t i;
   for (i = 0; i < size; i++) {

--- a/apron/ap_generic.c
+++ b/apron/ap_generic.c
@@ -32,8 +32,8 @@ bool ap_generic_sat_tcons(ap_manager_t* man, void* abs, ap_tcons0_t* cons,
 			     ap_scalar_discr_t discr,
 			     bool quasilinearize)
 {
-  bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
-  bool (*sat_lincons)(ap_manager_t*,...) = man->funptr[AP_FUNID_SAT_LINCONS];
+  bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
+  bool (*sat_lincons)(ap_manager_t*,void*,ap_lincons0_t*) = man->funptr[AP_FUNID_SAT_LINCONS];
   bool exact;
   ap_lincons0_t lincons0;
   bool res;
@@ -62,8 +62,8 @@ bool ap_generic_sat_tcons(ap_manager_t* man, void* abs, ap_tcons0_t* cons,
 ap_interval_t* ap_generic_bound_texpr(ap_manager_t* man, void* abs, ap_texpr0_t* expr,
 				      ap_scalar_discr_t discr, bool quasilinearize)
 {
-  bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
-  ap_interval_t* (*bound_linexpr)(ap_manager_t*,...) = man->funptr[AP_FUNID_BOUND_LINEXPR];
+  bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
+  ap_interval_t* (*bound_linexpr)(ap_manager_t*,void*,ap_linexpr0_t*) = man->funptr[AP_FUNID_BOUND_LINEXPR];
   bool exact;
   ap_linexpr0_t* linexpr0;
   ap_interval_t* res;
@@ -89,7 +89,7 @@ ap_interval_t* ap_generic_bound_texpr(ap_manager_t* man, void* abs, ap_texpr0_t*
 ap_tcons0_array_t ap_generic_to_tcons_array(ap_manager_t* man,
 					    void* abs)
 {
-  ap_lincons0_array_t (*to_lincons_array)(ap_manager_t*,...) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
+  ap_lincons0_array_t (*to_lincons_array)(ap_manager_t*,void*) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
   ap_lincons0_array_t array = to_lincons_array(man,abs);
   ap_tcons0_array_t res = ap_tcons0_array_make(array.size);
   size_t i;
@@ -117,8 +117,8 @@ void* ap_generic_meetjoin_array(bool meet,
 				ap_manager_t* man,
 				void** tab, size_t size)
 {
-  void* (*copy)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
-  void* (*meetjoin)(ap_manager_t*,...) = man->funptr[meet ? AP_FUNID_MEET : AP_FUNID_JOIN];
+  void* (*copy)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
+  void* (*meetjoin)(ap_manager_t*,bool,void*,void*) = man->funptr[meet ? AP_FUNID_MEET : AP_FUNID_JOIN];
   size_t i;
   void* res;
   bool exact,best;
@@ -158,13 +158,13 @@ ap_generic_meet_quasilinearize_lincons_array(ap_manager_t* man,
   bool exact;
   ap_lincons0_array_t array2;
   void* res;
-  void* (*copy)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
-  bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+  void* (*copy)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
+  bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
 
   man->result.flag_exact = man->result.flag_best = true;
 
   if (is_bottom(man,abs) || array->size==0){
-    res = destructive ? abs : copy(abs);
+    res = destructive ? abs : copy(man,abs);
   }
   else {
     array2 = ap_quasilinearize_lincons0_array(man,abs,array,&exact,
@@ -194,8 +194,8 @@ ap_generic_meet_intlinearize_tcons_array(ap_manager_t* man,
   bool exact;
   ap_lincons0_array_t array2;
   void* res;
-  void* (*copy)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
-  bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+  void* (*copy)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
+  bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
   ap_abstract0_t a0;
 
   man->result.flag_exact = man->result.flag_best = true;
@@ -249,15 +249,15 @@ void* ap_generic_asssub_linexpr_array(bool assign,
 				      bool destructive, void* abs, ap_dim_t* tdim, ap_linexpr0_t** texpr, size_t size,
 				      void* dest)
 {
-  bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
-  void* (*copy)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
-  void* (*add_dimensions)(ap_manager_t*,...) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
-  void* (*permute_dimensions)(ap_manager_t*,...) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
-  void* (*remove_dimensions)(ap_manager_t*,...) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
-  void* (*meet_lincons_array)(ap_manager_t*,...) = man->funptr[AP_FUNID_MEET_LINCONS_ARRAY];
-  void* (*meet)(ap_manager_t*,...) = man->funptr[AP_FUNID_MEET];
-  void (*ap_free)(ap_manager_t*,...) = man->funptr[AP_FUNID_FREE];
-  ap_dimension_t (*dimension)(ap_manager_t*,...) = man->funptr[AP_FUNID_DIMENSION];
+  bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
+  void* (*copy)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
+  void* (*add_dimensions)(ap_manager_t*,bool,void*,ap_dimchange_t*,bool) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
+  void* (*permute_dimensions)(ap_manager_t*,bool,void*,ap_dimperm_t*) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
+  void* (*remove_dimensions)(ap_manager_t*,bool,void*,ap_dimchange_t*) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
+  void* (*meet_lincons_array)(ap_manager_t*,bool,void*,ap_lincons0_array_t*) = man->funptr[AP_FUNID_MEET_LINCONS_ARRAY];
+  void* (*meet)(ap_manager_t*,bool,void*,void*) = man->funptr[AP_FUNID_MEET];
+  void (*ap_free)(ap_manager_t*,void*) = man->funptr[AP_FUNID_FREE];
+  ap_dimension_t (*dimension)(ap_manager_t*,void*) = man->funptr[AP_FUNID_DIMENSION];
   size_t i;
   ap_dimension_t d, dsup;
   ap_dimchange_t dimchange;
@@ -384,15 +384,15 @@ void* ap_generic_asssub_texpr_array(bool assign,
 				    bool destructive, void* abs, ap_dim_t* tdim, ap_texpr0_t** texpr, size_t size,
 				    void* dest)
 {
-  bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
-  void* (*copy)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
-  void* (*add_dimensions)(ap_manager_t*,...) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
-  void* (*permute_dimensions)(ap_manager_t*,...) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
-  void* (*remove_dimensions)(ap_manager_t*,...) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
-  void* (*meet_tcons_array)(ap_manager_t*,...) = man->funptr[AP_FUNID_MEET_TCONS_ARRAY];
-  void* (*meet)(ap_manager_t*,...) = man->funptr[AP_FUNID_MEET];
-  void (*ap_free)(ap_manager_t*,...) = man->funptr[AP_FUNID_FREE];
-  ap_dimension_t (*dimension)(ap_manager_t*,...) = man->funptr[AP_FUNID_DIMENSION];
+  bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
+  void* (*copy)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
+  void* (*add_dimensions)(ap_manager_t*,bool,void*,ap_dimchange_t*,bool) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
+  void* (*permute_dimensions)(ap_manager_t*,bool,void*,ap_dimperm_t*) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
+  void* (*remove_dimensions)(ap_manager_t*,bool,void*,ap_dimchange_t*) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
+  void* (*meet_tcons_array)(ap_manager_t*,bool,void*,ap_tcons0_array_t*) = man->funptr[AP_FUNID_MEET_TCONS_ARRAY];
+  void* (*meet)(ap_manager_t*,bool,void*,void*) = man->funptr[AP_FUNID_MEET];
+  void (*ap_free)(ap_manager_t*,void*) = man->funptr[AP_FUNID_FREE];
+  ap_dimension_t (*dimension)(ap_manager_t*,void*) = man->funptr[AP_FUNID_DIMENSION];
   size_t i;
   ap_dimension_t d, dsup;
   ap_dimchange_t dimchange;

--- a/apron/ap_policy.c
+++ b/apron/ap_policy.c
@@ -91,8 +91,8 @@ bool ap_abstract0_policy_check_policy_abstract(
 
   res = ap_policy_check(funid,pman,policy);
   if (res && policy!=NULL && policy->value!=NULL){
-    size_t (*pfunptr)(ap_policy_manager_t*,...) = pman->funptr[AP_FUNPOLICYID_DIMENSION];
-    ap_dimension_t (*funptr)(ap_manager_t*, ...) = pman->man->funptr[AP_FUNID_DIMENSION];
+    size_t (*pfunptr)(ap_policy_manager_t*,void*) = pman->funptr[AP_FUNPOLICYID_DIMENSION];
+    ap_dimension_t (*funptr)(ap_manager_t*, void*) = pman->man->funptr[AP_FUNID_DIMENSION];
     size_t nbdims = pfunptr(pman,policy->value);
     ap_dimension_t dimen = funptr(pman->man,a->value);
     if (nbdims != dimen.intdim+dimen.realdim){
@@ -217,7 +217,7 @@ ap_abstract0_policy_meet_apply(ap_policy_manager_t* pman,
   if (ap_abstract0_checkman2(funid,pman->man,a1,a2) &&
       ap_abstract0_check_abstract2(funid,pman->man,a1,a2) &&
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,a1)){
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,bool,void*,void*) = pman->funptr[funpid];
     void* value = ptr(pman,policy->value,destructive,a1->value,a2->value);
     return ap_abstract0_cons2(pman->man,destructive,a1,value);
   }
@@ -241,7 +241,7 @@ ap_abstract0_policy_meet_array_apply(ap_policy_manager_t* pman,
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,tab[0])){
     size_t i;
     ap_abstract0_t* res;
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,void**,size_t) = pman->funptr[funpid];
     void** ntab = malloc(size*sizeof(void*));
     for (i=0;i<size;i++) ntab[i] = tab[i]->value;
     res = ap_abstract0_cons(pman->man,ptr(pman,policy->value,ntab,size));
@@ -269,7 +269,7 @@ ap_abstract0_policy_meet_lincons_array_apply(ap_policy_manager_t* pman,
   if (ap_abstract0_checkman1(funid,pman->man,a) &&
       ap_abstract0_check_lincons_array(funid,pman->man,dimension,array) &&
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,a)){
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,bool,void*,ap_lincons0_array_t*) = pman->funptr[funpid];
     void* value = ptr(pman,policy->value,destructive,a->value,array);
     return ap_abstract0_cons2(pman->man,destructive,a,value);
   }
@@ -291,7 +291,7 @@ ap_abstract0_policy_meet_tcons_array_apply(ap_policy_manager_t* pman,
   if (ap_abstract0_checkman1(funid,pman->man,a) &&
       ap_abstract0_check_tcons_array(funid,pman->man,dimension,array) &&
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,a)){
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,bool,void*,ap_tcons0_array_t*) = pman->funptr[funpid];
     void* value = ptr(pman,policy->value,destructive,a->value,array);
     return ap_abstract0_cons2(pman->man,destructive,a,value);
   }
@@ -312,7 +312,7 @@ ap_abstract0_policy_meet_improve(ap_policy_manager_t* pman,
   if (ap_abstract0_checkman2(funid,pman->man,a1,a2) &&
       ap_abstract0_check_abstract2(funid,pman->man,a1,a2) &&
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,a1)){
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,void*,void*) = pman->funptr[funpid];
     void* value = ptr(pman,(policy ? policy->value : NULL),a1->value,a2->value);
     return ap_policy_cons(pman,policy,value);
   }
@@ -332,7 +332,7 @@ ap_abstract0_policy_meet_array_improve(ap_policy_manager_t* pman,
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,tab[0])){
     size_t i;
     ap_policy_t* res;
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,void**,size_t) = pman->funptr[funpid];
     void** ntab = malloc(size*sizeof(void*));
     for (i=0;i<size;i++) ntab[i] = tab[i]->value;
     res = ap_policy_cons(pman,policy,ptr(pman,(policy ? policy->value : NULL),ntab,size));
@@ -354,7 +354,7 @@ ap_abstract0_policy_meet_lincons_array_improve(ap_policy_manager_t* pman,
   if (ap_abstract0_checkman1(funid,pman->man,a) &&
       ap_abstract0_check_lincons_array(funid,pman->man,dimension,array) &&
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,a)){
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,void*,ap_lincons0_array_t*) = pman->funptr[funpid];
     void* value = ptr(pman,(policy ? policy->value : NULL),a->value,array);
     return ap_policy_cons(pman,policy,value);
   }
@@ -373,7 +373,7 @@ ap_abstract0_policy_meet_tcons_array_improve(ap_policy_manager_t* pman,
   if (ap_abstract0_checkman1(funid,pman->man,a) &&
       ap_abstract0_check_tcons_array(funid,pman->man,dimension,array) &&
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,a)){
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,void*,ap_tcons0_array_t*) = pman->funptr[funpid];
     void* value = ptr(pman,(policy ? policy->value : NULL),a->value,array);
     return ap_policy_cons(pman,policy,value);
   }
@@ -560,7 +560,7 @@ ap_abstract1_policy_meet_array_apply(ap_policy_manager_t* pman, ap_policy_t* pol
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,tab[0].abstract0)){
     size_t i;
     ap_abstract0_t* res0;
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,void**,size_t) = pman->funptr[funpid];
     void** ntab = malloc(size*sizeof(void*));
     for (i=0;i<size;i++) ntab[i] = tab[i].abstract0->value;
     res0 = malloc(sizeof(ap_abstract0_t));
@@ -677,7 +677,7 @@ ap_abstract1_policy_meet_array_improve(ap_policy_manager_t* pman, ap_policy_t* p
       ap_abstract1_check_env_array(funid,pman->man,tab,size) &&
       ap_abstract0_policy_check_policy_abstract(funpid,pman,policy,tab[0].abstract0)){
     size_t i;
-    void* (*ptr)(ap_policy_manager_t*,...) = pman->funptr[funpid];
+    void* (*ptr)(ap_policy_manager_t*,void*,void**,size_t) = pman->funptr[funpid];
     void** ntab = malloc(size*sizeof(void*));
     for (i=0;i<size;i++) ntab[i] = tab[i].abstract0->value;
     res = ap_policy_cons(pman,policy,ptr(pman,policy->value,ntab,size));

--- a/apron/ap_reducedproduct.c
+++ b/apron/ap_reducedproduct.c
@@ -125,16 +125,16 @@ static void set_bottom(ap_reducedproduct_internal_t* intern,
   size_t i;
 
   ap_manager_t* man = intern->tmanagers[index];
-  ap_dimension_t (*dimension)(ap_manager_t*,...) = man->funptr[AP_FUNID_DIMENSION];
+  ap_dimension_t (*dimension)(ap_manager_t*,void*) = man->funptr[AP_FUNID_DIMENSION];
   ap_dimension_t dim = dimension(man,a->p[index]);
   for (i=0; i<intern->size; i++){
     if (i!=index){
       man = intern->tmanagers[i];
       if (i<index || destructive){
-	void (*free)(ap_manager_t*,...) = man->funptr[AP_FUNID_FREE];
+	void (*free)(ap_manager_t*,void*) = man->funptr[AP_FUNID_FREE];
 	free(man,a->p[i]);
       }
-      void* (*bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_BOTTOM];
+      void* (*bottom)(ap_manager_t*,int,int) = man->funptr[AP_FUNID_BOTTOM];
       a->p[i] = bottom(man, dim.intdim, dim.realdim);
     }
   }
@@ -153,7 +153,7 @@ void ap_reducedproduct_##NAME(ap_manager_t* manager, ap_reducedproduct_t* a) \
 									\
   for (i=0;i<intern->size;i++){						\
     ap_manager_t* man = intern->tmanagers[i];				\
-    void (*ptr)(ap_manager_t*,...) = man->funptr[FUNID];		\
+    void (*ptr)(ap_manager_t*,void*) = man->funptr[FUNID];		\
     ptr(man,a->p[i]);							\
   }									\
   collect_results1(manager,FUNID,a);					\
@@ -172,7 +172,7 @@ ap_reducedproduct_t* ap_reducedproduct_copy(ap_manager_t* manager, ap_reducedpro
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
+    void* (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
     res->p[i] = ptr(man,a->p[i]);
   }
   res->reduced = a->reduced;
@@ -188,7 +188,7 @@ void ap_reducedproduct_free(ap_manager_t* manager, ap_reducedproduct_t* a)
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_FREE];
+    void (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_FREE];
     ptr(man,a->p[i]);
   }
   free(a);
@@ -203,7 +203,7 @@ size_t ap_reducedproduct_size(ap_manager_t* manager, ap_reducedproduct_t* a)
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    size_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_ASIZE];
+    size_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_ASIZE];
     res += ptr(man,a->p[i]);
   }
   collect_results0(manager);
@@ -224,7 +224,7 @@ int ap_reducedproduct_hash(ap_manager_t* manager, ap_reducedproduct_t* a)
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    size_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_HASH];
+    size_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_HASH];
     res += ptr(man,a->p[i]);
   }
   collect_results0(manager);
@@ -251,7 +251,7 @@ void ap_reducedproduct_fprint(FILE* stream, ap_manager_t* manager,
   fprintf(stream,"reduced product of library %s\n",manager->library);
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void (*ptr)(FILE* stream, ap_manager_t*,...) = man->funptr[AP_FUNID_FPRINT];
+    void (*ptr)(FILE* stream, ap_manager_t*,void*,char**) = man->funptr[AP_FUNID_FPRINT];
     ptr(stream,man,a->p[i],name_of_dim);
   }
   collect_results0(manager);
@@ -266,7 +266,7 @@ void ap_reducedproduct_fprintdiff(FILE* stream, ap_manager_t* manager,
   fprintf(stream,"reduced product of library %s\n",manager->library);
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void (*ptr)(FILE* stream, ap_manager_t*,...) = man->funptr[AP_FUNID_FPRINTDIFF];
+    void (*ptr)(FILE* stream, ap_manager_t*,void*,void*,char**) = man->funptr[AP_FUNID_FPRINTDIFF];
     ptr(stream,man,a->p[i],b->p[i],name_of_dim);
   }
   collect_results0(manager);
@@ -280,7 +280,7 @@ void ap_reducedproduct_fdump(FILE* stream, ap_manager_t* manager,
   fprintf(stream,"reduced product of library %s\n",manager->library);
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void (*ptr)(FILE* stream, ap_manager_t*,...) = man->funptr[AP_FUNID_FDUMP];
+    void (*ptr)(FILE* stream, ap_manager_t*,void*) = man->funptr[AP_FUNID_FDUMP];
     ptr(stream,man,a->p[i]);
   }
   collect_results0(manager);
@@ -300,7 +300,7 @@ ap_membuf_t ap_reducedproduct_serialize_raw(ap_manager_t* manager, ap_reducedpro
   gres.size = 0;
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    ap_membuf_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_SERIALIZE_RAW];
+    ap_membuf_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_SERIALIZE_RAW];
     ap_membuf_t res = ptr(man,a->p[i]);
     gres.ptr = realloc(gres.ptr, gres.size + res.size);
     memcpy(((char*)gres.ptr + gres.size), res.ptr, res.size);
@@ -320,7 +320,7 @@ ap_reducedproduct_t* ap_reducedproduct_deserialize_raw(ap_manager_t* manager, vo
   *size = 0;
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_DESERIALIZE_RAW];
+    void* (*ptr)(ap_manager_t*,char*,size_t*) = man->funptr[AP_FUNID_DESERIALIZE_RAW];
     size_t nb;
     res->p[i] = ptr(man,((char*)p + *size), &nb);
     *size += nb;
@@ -345,7 +345,7 @@ ap_reducedproduct_t* ap_reducedproduct_##NAME(ap_manager_t* manager, size_t intd
 									\
   for (i=0;i<intern->size;i++){						\
     ap_manager_t* man = intern->tmanagers[i];				\
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[FUNID];		\
+    void* (*ptr)(ap_manager_t*,size_t,size_t) = man->funptr[FUNID];		\
     res->p[i] = ptr(man,intdim,realdim);				\
   }									\
   res->reduced = true;							\
@@ -366,9 +366,9 @@ ap_reducedproduct_t* ap_reducedproduct_of_box(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_OF_BOX];
+    void* (*ptr)(ap_manager_t*,size_t,size_t,ap_interval_t**) = man->funptr[AP_FUNID_OF_BOX];
     res->p[i] = ptr(man,intdim,realdim,tinterval);
-    bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+    bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
     if (is_bottom(man,res->p[i])){
       set_bottom(intern,false,res,i);
       break;
@@ -382,7 +382,7 @@ ap_dimension_t ap_reducedproduct_dimension(ap_manager_t* manager, ap_reducedprod
 {
   ap_reducedproduct_internal_t* intern = get_internal_init0(manager);
   ap_manager_t* man = intern->tmanagers[0];
-  ap_dimension_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_DIMENSION];
+  ap_dimension_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_DIMENSION];
   return ptr(man,a->p[0]);
 }
 
@@ -398,7 +398,7 @@ bool ap_reducedproduct_is_bottom(ap_manager_t* manager, ap_reducedproduct_t* a)
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+    bool (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
     bool res = ptr(man,a->p[i]);
     gres = gres || res;
     if (gres) break;
@@ -414,7 +414,7 @@ bool ap_reducedproduct_is_top(ap_manager_t* manager, ap_reducedproduct_t* a)
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_TOP];
+    bool (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_TOP];
     bool res = ptr(man,a->p[i]);
     gres = gres && res;
     if (!gres) break;
@@ -433,7 +433,7 @@ bool ap_reducedproduct_##NAME(ap_manager_t* manager, ap_reducedproduct_t* a,  ap
 									\
   for (i=0;i<intern->size;i++){						\
     ap_manager_t* man = intern->tmanagers[i];				\
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[FUNID];		\
+    bool (*ptr)(ap_manager_t*,void*,void*) = man->funptr[FUNID];		\
     bool res = ptr(man,a->p[i],b->p[i]);			       	\
     gres = gres && res;							\
     if (!gres) break;							\
@@ -453,7 +453,7 @@ bool ap_reducedproduct_sat_lincons(ap_manager_t* manager, ap_reducedproduct_t* a
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_SAT_LINCONS];
+    bool (*ptr)(ap_manager_t*,void*,ap_lincons0_t*) = man->funptr[AP_FUNID_SAT_LINCONS];
     bool res = ptr(man,a->p[i],lincons);
     gres = gres || res;
     if (gres) break;
@@ -469,7 +469,7 @@ bool ap_reducedproduct_sat_tcons(ap_manager_t* manager, ap_reducedproduct_t* a, 
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_SAT_TCONS];
+    bool (*ptr)(ap_manager_t*,void*,ap_tcons0_t*) = man->funptr[AP_FUNID_SAT_TCONS];
     bool res = ptr(man,a->p[i],tcons);
     gres = gres || res;
     if (gres) break;
@@ -486,7 +486,7 @@ bool ap_reducedproduct_sat_interval(ap_manager_t* manager, ap_reducedproduct_t* 
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_SAT_INTERVAL];
+    bool (*ptr)(ap_manager_t*,void*,ap_dim_t,ap_interval_t*) = man->funptr[AP_FUNID_SAT_INTERVAL];
     bool res = ptr(man,a->p[i],dim,interval);
     gres = gres || res;
     if (gres) break;
@@ -504,7 +504,7 @@ bool ap_reducedproduct_is_dimension_unconstrained(ap_manager_t* manager, ap_redu
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    bool (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_DIMENSION_UNCONSTRAINED];
+    bool (*ptr)(ap_manager_t*,void*,ap_dim_t) = man->funptr[AP_FUNID_IS_DIMENSION_UNCONSTRAINED];
     bool res = ptr(man,a->p[i],dim);
     gres = gres && res;
     if (!gres) break;
@@ -539,7 +539,7 @@ ap_interval_t* ap_reducedproduct_bound_linexpr(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    ap_interval_t* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_BOUND_LINEXPR];
+    ap_interval_t* (*ptr)(ap_manager_t*,void*,ap_linexpr0_t*) = man->funptr[AP_FUNID_BOUND_LINEXPR];
     ap_interval_t* res = ptr(man,a->p[i],expr);
     ap_interval_meet_with(gres,res);
     ap_interval_free(res);
@@ -560,7 +560,7 @@ ap_interval_t* ap_reducedproduct_bound_texpr(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    ap_interval_t* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_BOUND_TEXPR];
+    ap_interval_t* (*ptr)(ap_manager_t*,void*,ap_texpr0_t*) = man->funptr[AP_FUNID_BOUND_TEXPR];
     ap_interval_t* res = ptr(man,a->p[i],expr);
     ap_interval_meet_with(gres,res);
     ap_interval_free(res);
@@ -581,7 +581,7 @@ ap_interval_t* ap_reducedproduct_bound_dimension(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    ap_interval_t* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_BOUND_DIMENSION];
+    ap_interval_t* (*ptr)(ap_manager_t*,void*,ap_dim_t) = man->funptr[AP_FUNID_BOUND_DIMENSION];
     ap_interval_t* res = ptr(man,a->p[i],dim);
     ap_interval_meet_with(gres,res);
     ap_interval_free(res);
@@ -602,7 +602,7 @@ ap_lincons0_array_t ap_reducedproduct_to_lincons_array(ap_manager_t* manager, ap
   garray.size = 0;
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    ap_lincons0_array_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
+    ap_lincons0_array_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_TO_LINCONS_ARRAY];
     ap_lincons0_array_t array = ptr(man,a->p[i]);
     garray.p = realloc(garray.p, (garray.size + array.size) * sizeof(ap_lincons0_t));
     for (j=0;j<array.size;j++){
@@ -625,7 +625,7 @@ ap_tcons0_array_t ap_reducedproduct_to_tcons_array(ap_manager_t* manager, ap_red
   garray.size = 0;
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    ap_tcons0_array_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_TO_TCONS_ARRAY];
+    ap_tcons0_array_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_TO_TCONS_ARRAY];
     ap_tcons0_array_t array = ptr(man,a->p[i]);
     garray.p = realloc(garray.p, (garray.size + array.size) * sizeof(ap_tcons0_t));
     for (j=0;j<array.size;j++){
@@ -647,11 +647,11 @@ ap_interval_t** ap_reducedproduct_to_box(ap_manager_t* manager, ap_reducedproduc
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    ap_interval_t** (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_TO_BOX];
+    ap_interval_t** (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_TO_BOX];
     ap_interval_t** box = ptr(man,a->p[i]);
     if (i==0){
       gbox = box;
-      ap_dimension_t (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_DIMENSION];
+      ap_dimension_t (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_DIMENSION];
       ap_dimension_t dimension = ptr(man,a->p[i]);
       nbdims = dimension.intdim+dimension.realdim;
     }
@@ -705,10 +705,10 @@ ap_reducedproduct_t* ap_reducedproduct_meetjoin(ap_funid_t funid,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[funid];
+    void* (*ptr)(ap_manager_t*,bool,void*,void*) = man->funptr[funid];
     res->p[i] = ptr(man,destructive,a1->p[i],a2->p[i]);
     if (funid==AP_FUNID_MEET){
-      bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+      bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
       if (is_bottom(man,res->p[i])){
 	set_bottom(intern,destructive,res,i);
 	goto ap_reducedproduct_meetjoin_exit;
@@ -745,13 +745,13 @@ ap_reducedproduct_t* ap_reducedproduct_meetjoin_array(ap_funid_t funid,
   a = (void**)malloc(size*sizeof(void*));
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[funid];
+    void* (*ptr)(ap_manager_t*,void**,size_t) = man->funptr[funid];
     for (j=0;j<size;j++){
       a[j] = tab[j]->p[i];
     }
     res->p[i] = ptr(man,a,size);
     if (funid==AP_FUNID_MEET_ARRAY){
-      bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+      bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
       if (is_bottom(man,res->p[i])){
 	set_bottom(intern,false,res,i);
 	goto ap_reducedproduct_meetjoin_array_exit;
@@ -797,9 +797,9 @@ ap_reducedproduct_t* ap_reducedproduct_meet_lincons_array(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_MEET_LINCONS_ARRAY];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_lincons0_array_t*) = man->funptr[AP_FUNID_MEET_LINCONS_ARRAY];
     res->p[i] = ptr(man,destructive,a->p[i],array);
-    bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+    bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
     if (is_bottom(man,res->p[i])){
       set_bottom(intern,destructive,res,i);
       break;
@@ -822,9 +822,9 @@ ap_reducedproduct_t* ap_reducedproduct_meet_tcons_array(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_MEET_TCONS_ARRAY];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_tcons0_array_t*) = man->funptr[AP_FUNID_MEET_TCONS_ARRAY];
     res->p[i] = ptr(man,destructive,a->p[i],array);
-    bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+    bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
     if (is_bottom(man,res->p[i])){
       set_bottom(intern,destructive,res,i);
       break;
@@ -847,7 +847,7 @@ ap_reducedproduct_t* ap_reducedproduct_add_ray_array(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_ADD_RAY_ARRAY];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_lincons0_array_t*) = man->funptr[AP_FUNID_ADD_RAY_ARRAY];
     res->p[i] = ptr(man,destructive,a->p[i],array);
   }
   res->reduced = a->reduced;
@@ -876,10 +876,10 @@ ap_reducedproduct_asssub_linexpr_array(ap_funid_t funid,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[funid];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t*,ap_linexpr0_t**,size_t,ap_reducedproduct_t*) = man->funptr[funid];
     res->p[i] = ptr(man,destructive,a->p[i],tdim,texpr,size, dest ? dest->p[i] : NULL);
     if (dest || funid==AP_FUNID_SUBSTITUTE_LINEXPR_ARRAY){
-      bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+      bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
       if (is_bottom(man,res->p[i])){
 	set_bottom(intern,destructive,res,i);
 	break;
@@ -930,10 +930,10 @@ ap_reducedproduct_asssub_texpr_array(ap_funid_t funid,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[funid];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t*,ap_texpr0_t**,size_t,ap_reducedproduct_t*) = man->funptr[funid];
     res->p[i] = ptr(man,destructive,a->p[i],tdim,texpr,size, dest ? dest->p[i] : NULL);
     if (dest || funid==AP_FUNID_SUBSTITUTE_TEXPR_ARRAY){
-      bool (*is_bottom)(ap_manager_t*,...) = man->funptr[AP_FUNID_IS_BOTTOM];
+      bool (*is_bottom)(ap_manager_t*,void*) = man->funptr[AP_FUNID_IS_BOTTOM];
       if (is_bottom(man,res->p[i])){
 	set_bottom(intern,destructive,res,i);
 	break;
@@ -985,7 +985,7 @@ ap_reducedproduct_t* ap_reducedproduct_forget_array(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_FORGET_ARRAY];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t*,size_t,bool) = man->funptr[AP_FUNID_FORGET_ARRAY];
     res->p[i] = ptr(man,destructive,a->p[i],tdim,size,project);
   }
   res->reduced = a->reduced;
@@ -1007,7 +1007,7 @@ ap_reducedproduct_t* ap_reducedproduct_add_dimensions(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_dimchange_t*,bool) = man->funptr[AP_FUNID_ADD_DIMENSIONS];
     res->p[i] = ptr(man,destructive,a->p[i],dimchange,project);
   }
   res->reduced = a->reduced;
@@ -1027,7 +1027,7 @@ ap_reducedproduct_t* ap_reducedproduct_remove_dimensions(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_dimchange_t*) = man->funptr[AP_FUNID_REMOVE_DIMENSIONS];
     res->p[i] = ptr(man,destructive,a->p[i],dimchange);
   }
   res->reduced = false;
@@ -1048,7 +1048,7 @@ ap_reducedproduct_t* ap_reducedproduct_permute_dimensions(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_dimperm_t*) = man->funptr[AP_FUNID_PERMUTE_DIMENSIONS];
     res->p[i] = ptr(man,destructive,a->p[i],perm);
   }
   res->reduced = a->reduced;
@@ -1074,7 +1074,7 @@ ap_reducedproduct_t* ap_reducedproduct_expand(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_EXPAND];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t,size_t) = man->funptr[AP_FUNID_EXPAND];
     res->p[i] = ptr(man,destructive,a->p[i],dim,n);
   }
   res->reduced = a->reduced;
@@ -1095,7 +1095,7 @@ ap_reducedproduct_t* ap_reducedproduct_fold(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_FOLD];
+    void* (*ptr)(ap_manager_t*,bool,void*,ap_dim_t*,size_t) = man->funptr[AP_FUNID_FOLD];
     res->p[i] = ptr(man,destructive,a->p[i],tdim,size);
   }
   res->reduced = false;
@@ -1118,7 +1118,7 @@ ap_reducedproduct_t* ap_reducedproduct_widening(ap_manager_t* manager,
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_WIDENING];
+    void* (*ptr)(ap_manager_t*,void*,void*) = man->funptr[AP_FUNID_WIDENING];
     res->p[i] = ptr(man,a1->p[i],a2->p[i]);
   }
   res->reduced = false;
@@ -1140,7 +1140,7 @@ ap_reducedproduct_t* ap_reducedproduct_closure(ap_manager_t* manager, bool destr
 
   for (i=0;i<intern->size;i++){
     ap_manager_t* man = intern->tmanagers[i];
-    void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_CLOSURE];
+    void* (*ptr)(ap_manager_t*,bool,void*) = man->funptr[AP_FUNID_CLOSURE];
     res->p[i] = ptr(man,destructive,a->p[i]);
   }
   res->reduced = false;
@@ -1320,7 +1320,7 @@ void** ap_reducedproduct_decompose(ap_manager_t* manager, bool destructive, ap_r
     }
     else {
       ap_manager_t* man = intern->tmanagers[i];
-      void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
+      void* (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
       res[i] = ptr(man,a->p[i]);
     }
   }
@@ -1341,7 +1341,7 @@ ap_reducedproduct_t* ap_reducedproduct_compose(ap_manager_t* manager, bool destr
     }
     else {
       ap_manager_t* man = intern->tmanagers[i];
-      void* (*ptr)(ap_manager_t*,...) = man->funptr[AP_FUNID_COPY];
+      void* (*ptr)(ap_manager_t*,void*) = man->funptr[AP_FUNID_COPY];
       res->p[i] = ptr(man,tabs[i]);
     }
   }

--- a/mlapronidl/apron_caml.c
+++ b/mlapronidl/apron_caml.c
@@ -317,8 +317,8 @@ void camlidl_apron_abstract0_serialize(value v, unsigned long * w32, unsigned lo
   ap_abstract0_ptr* p = (ap_abstract0_ptr *) Data_custom_val(v);
   ap_abstract0_t* a = *p;
   ap_membuf_t buf = ap_abstract0_serialize_raw(a->man,a);
-  serialize_int_8(buf.size);
-  serialize_block_1(buf.ptr,buf.size);
+  caml_serialize_int_8(buf.size);
+  caml_serialize_block_1(buf.ptr,buf.size);
   *w32 = 4;
   *w64 = 8;
 }
@@ -327,11 +327,11 @@ static
 unsigned long camlidl_apron_abstract0_deserialize(void * dst)
 {
   if (deserialize_man) {
-    size_t size = deserialize_uint_8(), realsize;
+    size_t size = caml_deserialize_uint_8(), realsize;
     void* data;
     data = malloc(size);
     assert(data);
-    deserialize_block_1(data,size);
+    caml_deserialize_block_1(data,size);
     *((ap_abstract0_ptr*)dst) =
       ap_abstract0_deserialize_raw(deserialize_man,data,&realsize);
     free(data);
@@ -457,7 +457,7 @@ value camlidl_apron_environment_ptr_c2ml(ap_environment_ptr* p)
 {
   value v;
 
-   v = alloc_custom(&camlidl_apron_custom_environment_ptr, sizeof(ap_environment_ptr), 0,1);
+   v = caml_alloc_custom(&camlidl_apron_custom_environment_ptr, sizeof(ap_environment_ptr), 0,1);
   *((ap_environment_ptr *) Data_custom_val(v)) = *p;
   return v;
 }
@@ -467,7 +467,7 @@ value camlidl_apron_environment_ptr_c2ml(ap_environment_ptr* p)
 /* ********************************************************************** */
 value camlidl_apron_init(value dummy)
 {
-  register_custom_operations(&camlidl_apron_custom_abstract0_ptr);
+  caml_register_custom_operations(&camlidl_apron_custom_abstract0_ptr);
   return Val_unit;
 }
 /* ********************************************************************** */
@@ -484,7 +484,7 @@ value camlidl_apron_policy_optr_c2ml(ap_policy_optr* p)
     value v,v2=0;
     Begin_roots1(v2);
     v2 = camlidl_apron_policy_ptr_c2ml(p);
-    v = alloc_small(1,0);
+    v = caml_alloc_small(1,0);
     Field(v,0) = v2;
     End_roots();
     return v;

--- a/mlapronidl/apron_caml.h
+++ b/mlapronidl/apron_caml.h
@@ -116,7 +116,7 @@ static inline
 value camlidl_apron_linexpr0_ptr_c2ml(ap_linexpr0_ptr* p)
 {
   value v;
-  v = alloc_custom(&camlidl_apron_custom_linexpr0_ptr, sizeof(ap_linexpr0_ptr), 0,1);
+  v = caml_alloc_custom(&camlidl_apron_custom_linexpr0_ptr, sizeof(ap_linexpr0_ptr), 0,1);
   *((ap_linexpr0_ptr *) Data_custom_val(v)) = *p;
   return v;
 }
@@ -146,7 +146,7 @@ static inline
 value camlidl_apron_texpr0_ptr_c2ml(ap_texpr0_ptr* p)
 {
   value v;
-  v = alloc_custom(&camlidl_apron_custom_texpr0_ptr, sizeof(ap_texpr0_ptr), 0,1);
+  v = caml_alloc_custom(&camlidl_apron_custom_texpr0_ptr, sizeof(ap_texpr0_ptr), 0,1);
   *((ap_texpr0_ptr *) Data_custom_val(v)) = *p;
   return v;
 }
@@ -199,7 +199,7 @@ static inline
 value camlidl_apron_manager_ptr_c2ml(ap_manager_ptr* p)
 {
   value v;
-  v = alloc_custom(&camlidl_apron_custom_manager_ptr, sizeof(ap_manager_ptr),
+  v = caml_alloc_custom(&camlidl_apron_custom_manager_ptr, sizeof(ap_manager_ptr),
 		   0,1);
   *((ap_manager_ptr *) Data_custom_val(v)) = *p;
   return v;
@@ -230,7 +230,7 @@ value camlidl_apron_abstract0_ptr_c2ml(ap_abstract0_ptr* p)
 {
   value v;
   assert((*p)->man!=NULL);
-  v = alloc_custom(&camlidl_apron_custom_abstract0_ptr, sizeof(ap_abstract0_ptr),
+  v = caml_alloc_custom(&camlidl_apron_custom_abstract0_ptr, sizeof(ap_abstract0_ptr),
 		   ap_abstract0_size((*p)->man,(*p)),
 		   camlidl_apron_heap);
   *((ap_abstract0_ptr *) Data_custom_val(v)) = *p;
@@ -307,7 +307,7 @@ value camlidl_apron_var_ptr_c2ml(ap_var_t* p)
 {
   value v;
 
-  v = alloc_custom(&camlidl_apron_custom_var_ptr, sizeof(apron_var_ptr), 0,1);
+  v = caml_alloc_custom(&camlidl_apron_custom_var_ptr, sizeof(apron_var_ptr), 0,1);
   *((ap_var_t *) Data_custom_val(v)) = *p;
   return v;
 }
@@ -355,7 +355,7 @@ static inline
 value camlidl_apron_policy_manager_ptr_c2ml(ap_policy_manager_ptr* p)
 {
   value v;
-  v = alloc_custom(&camlidl_apron_custom_policy_manager_ptr, sizeof(ap_policy_manager_ptr),
+  v = caml_alloc_custom(&camlidl_apron_custom_policy_manager_ptr, sizeof(ap_policy_manager_ptr),
 		   0,1);
   *((ap_policy_manager_ptr *) Data_custom_val(v)) = *p;
   return v;
@@ -384,7 +384,7 @@ value camlidl_apron_policy_ptr_c2ml(ap_policy_ptr* p)
 {
   value v;
   assert((*p)->pman!=NULL);
-  v = alloc_custom(&camlidl_apron_custom_policy_ptr, sizeof(ap_policy_ptr),
+  v = caml_alloc_custom(&camlidl_apron_custom_policy_ptr, sizeof(ap_policy_ptr),
 		   0,1);
   *((ap_policy_ptr *) Data_custom_val(v)) = *p;
   return v;


### PR DESCRIPTION
Calling conventions on Apple M1 seem to differ for varargs: the program below prints "The answer is <some arbitrary value>" on M1 while it prints "The answer is 42" on Linux.

```
void f(int something, int answer) {
  printf("The answer is %d\n", answer);
}

int
main(int argc, char *argv[])
{
  void (*ptr)(int, ...) = (void *) f;
  ptr(18, 42);
}
```

This commit fixes all type annotations for functions that are extracted from `ap_manager_t*`. This solves segmentation faults  observed when apron is compiled on Apple M1.

Another solution would have been to use the type `void (*ptr)()`, but expliciting types look like a safer approach. Types allow us to find and fix the following suspicious line (`apron/ap_generic.c`, line 167):

```
    res = destructive ? abs : copy(abs);
```

whereas `copy` is `AP_FUNID_COPY` of type `void* (*copy)(ap_manager_t*,void*)` (the argument `man` was obviously missing).