### PR TITLE
Write soname field in Linux-based shared libraries

### DIFF
--- a/configure
+++ b/configure
@@ -534,6 +534,10 @@ else
     fi
 fi
 
+if test "x$(uname -s)" = "xLinux"
+then
+	  linux_install_soname=1
+fi
 
 ##############################################
 # log
@@ -645,6 +649,8 @@ TEXI2ANY = texi2any
 
 # OSX only:
 ABSOLUTE_DYLIB_INSTALL_NAMES = $absolute_dylib_install_names
+
+LINUX_INSTALL_SONAME = $linux_install_soname
 
 EOF
 

--- a/vars.mk
+++ b/vars.mk
@@ -68,6 +68,10 @@ ifneq ($(HAS_SHARED),)
     OCAMLMKLIB := $(OCAMLMKLIB) -dllpath $(APRON_LIB)
     OCAMLMKLIB := $(OCAMLMKLIB) -L$(APRON_LIB)
   endif
+  ifneq ($(LINUX_INSTALL_SONAME),)
+    CC_APRON_DYLIB += -Wl,-soname,$@
+    CXX_APRON_DYLIB += -Wl,-soname,$@
+  endif
   ifneq ($(ABSOLUTE_DYLIB_INSTALL_NAMES),)
     CC_APRON_DYLIB += -install_name $(APRON_LIB)/$@
     CXX_APRON_DYLIB += -install_name $(APRON_LIB)/$@


### PR DESCRIPTION
Closes #6.

From `apron`'s repository, when everything is built, you can check it by either:
1) running `objdump -p apron/libapron.so | grep SONAME` 
2) running `LD_LIBRARY_PATH=$(realpath apron) python3 -c "from ctypes import CDLL, util; print(CDLL(util.find_library('apron')))"` and checking that the output is `<CDLL 'libapron.so', ...>`