### PR TITLE
Fix for make 4.4: ignore errors including depend if it does not exist

### DIFF
--- a/apron/Makefile
+++ b/apron/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.config
 include ../vars.mk
 include ../version.mk
-include depend
+-include depend
 
 #---------------------------------------
 # C part


### PR DESCRIPTION
closes #56
