### PR TITLE
Fix bsearch2 prototype, fixing segfault on Apple M1

### DIFF
--- a/newpolka/pk_widening.c
+++ b/newpolka/pk_widening.c
@@ -102,7 +102,7 @@ typedef struct bsearch_man_t {
   size_t size;
 } bsearch_man_t;
 
-static bool bsearch2(bsearch_man_t* man, size_t low, size_t high)
+static int bsearch2(bsearch_man_t* man, size_t low, size_t high)
 {
   if (high - low <= 4){
     size_t i;


### PR DESCRIPTION
`bsearch2` was declared to return (unsigned) `bool` instead of `int`, leading return value `-1` to be miss-interpreted as `255`, making wrong comparison results for instance in `pk_widening`, which led to observable segmentation faults on Apple M1.