### PR TITLE
Solving build problems with ppl and glpk on custom paths

### DIFF
--- a/fppol/Makefile
+++ b/fppol/Makefile
@@ -22,7 +22,7 @@ include ../vars.mk
 #---------------------------------------
 
 ICFLAGS += $(BASE_ICFLAGS) $(ML_ICFLAGS) $(GLPK_ICFLAGS)
-LDFLAGS += $(BASE_LIFLAGS) $(GLPK_ICFLAGS)
+LDFLAGS += $(BASE_LIFLAGS) $(GLPK_LIFLAGS)
 CMXSINC = $(APRON_CMXSINC) -I .
 
 #---------------------------------------
@@ -275,10 +275,10 @@ endif
 #	$(OCAMLC) -noautolink $(OCAMLFLAGS) $(OCAMLINC) -o $@ -make-runtime bigarray.cma gmp.cma apron.cma fpp.cma -ccopt "-L. -L../mlapronidl $(LDFLAGS)" -cclib "-lfpp_caml -lfpp$* -lapron_caml -lapron -lgmp_caml -lmpfr -lgmp -lglpk -lbigarray -lcamlidl"
 
 fpp%.cma: fpp.cmo libfpp%_caml.a libfpp%.a
-	$(OCAMLMKLIB) -o fpp$* -oc fpp$*_caml fpp.cmo -lfpp$* $(LIBS)
+	$(OCAMLMKLIB) -o fpp$* -oc fpp$*_caml fpp.cmo -lfpp$* $(LDFLAGS) $(LIBS)
 
 fpp%.cmxa fpp%.a: fpp.cmx libfpp%_caml.a libfpp%.a
-	$(OCAMLMKLIB) -o fpp$* -oc fpp$*_caml fpp.cmx -lfpp$* $(LIBS)
+	$(OCAMLMKLIB) -o fpp$* -oc fpp$*_caml fpp.cmx -lfpp$* $(LDFLAGS) $(LIBS)
 
 dllfpp%_caml.$(EXT_DLL) libfpp%_caml.a: fpp_caml.o libfpp%.a
 	$(OCAMLMKLIB) -o fpp$*_caml $< -L. -lfpp$* $(LDFLAGS) $(LIBS)

--- a/ppl/Makefile
+++ b/ppl/Makefile
@@ -162,11 +162,11 @@ libap_ppl_caml_debug.a: ap_ppl_caml_debug.o libap_ppl_debug.a
 	$(OCAMLMKLIB) -o ap_ppl_caml_debug $< -L. -lap_ppl_debug $(LDFLAGS) $(LIBS_DEBUG)
 
 ppl.cma: ppl.cmo libap_ppl_caml.a libap_ppl.a
-	$(OCAMLMKLIB) -o ppl -oc ap_ppl_caml ppl.cmo -lap_ppl $(LIBS)
+	$(OCAMLMKLIB) -o ppl -oc ap_ppl_caml ppl.cmo -lap_ppl $(LDFLAGS) $(LIBS)
 
 ppl.cmxa: ppl.a
 ppl.a: ppl.cmx libap_ppl_caml.a libap_ppl.a
-	$(OCAMLMKLIB) -o ppl -oc ap_ppl_caml ppl.cmx -lap_ppl $(LIBS)
+	$(OCAMLMKLIB) -o ppl -oc ap_ppl_caml ppl.cmx -lap_ppl $(LDFLAGS) $(LIBS)
 
 
 #---------------------------------------

--- a/products/Makefile
+++ b/products/Makefile
@@ -143,11 +143,11 @@ libpolkaGrid_caml_debug.a: polkaGrid_caml_debug.o libap_pkgrid_debug.a
 #---------------------------------------
 
 polkaGrid.cma: polkaGrid.cmo libpolkaGrid_caml.a libap_pkgrid.a
-	$(OCAMLMKLIB) -o polkaGrid -oc polkaGrid_caml polkaGrid.cmo -lap_pkgrid $(LIBS)
+	$(OCAMLMKLIB) -o polkaGrid -oc polkaGrid_caml polkaGrid.cmo -lap_pkgrid $(LDFLAGS) $(LIBS)
 
 polkaGrid.cmxa: polkaGrid.a
 polkaGrid.a: polkaGrid.cmx libpolkaGrid_caml.a libap_pkgrid.a
-	$(OCAMLMKLIB) -o polkaGrid -oc polkaGrid_caml polkaGrid.cmx -lap_pkgrid $(LIBS)
+	$(OCAMLMKLIB) -o polkaGrid -oc polkaGrid_caml polkaGrid.cmx -lap_pkgrid $(LDFLAGS) $(LIBS)
 
 #---------------------------------------
 # IDL rules

--- a/vars.mk
+++ b/vars.mk
@@ -56,6 +56,13 @@ ifneq ($(PPL_PREFIX),)
   PPL_ICFLAGS += -I$(PPL_PREFIX)/include
   PPL_LIFLAGS += -L$(PPL_PREFIX)lib
 endif
+ 
+GLPK_ICFLAGS =
+GLPK_LIFLAGS =
+ifneq ($(GLPK_PREFIX),)
+  GLPK_ICFLAGS += -I$(GLPK_PREFIX)/include
+  GLPK_LIFLAGS += -L$(GLPK_PREFIX)lib
+endif
 
 # ---
 


### PR DESCRIPTION
When building with the following command line:
```
./configure --ppl-prefix ~/installs/ppl-1.2/ --glpk-prefix ~/installs/glpk-5.0/ --prefix ~/installs/apron/
make
```
having ppl and glpk installed to custom directories make few `cc`/`ld` errors appear:
- from `fppol/Makefile:214`:
```
rlp.h:22:10: fatal error: glpk.h: No such file or directory
    22 | #include <glpk.h> /* linear programming lib */
       |          ^~~~~~~~
```
- from `ppl/Makefile:205`:
```
/usr/bin/ld: cannot find -lppl: No such file or directory
```
- from `products/Makefile:182`:
```
/usr/bin/ld: cannot find -lppl: No such file or directory
```

The correct library includes are now passed along the command lines that had problems.