### PR TITLE
Disable ap_pplite build if there is no C++ compiler.

### DIFF
--- a/configure
+++ b/configure
@@ -101,7 +101,8 @@ while : ; do
 	    shift;;
         -no-cxx|--no-cxx)
             has_cxx=0
-            has_ppl=0;;
+            has_ppl=0
+            has_pplite=0;;
         -no-ppl|--no-ppl)
             has_ppl=0;;
         -no-pplite|--no-pplite)


### PR DESCRIPTION
Quick fix to let it compile even when there is no C++ compiler.

(Note: probably it would be cleaner to separate absence of C++ compiler from disabling of C++ interfaces; now these are coded using the same setting -no-cxx)