### PR TITLE
Use strip --strip-unneeded for stripping.

### DIFF
--- a/apron/Makefile
+++ b/apron/Makefile
@@ -84,7 +84,7 @@ install: all
 	mkdir -p $(APRON_INCLUDE)
 	cp $(H_FILES) $(APRON_INCLUDE)
 	mkdir -p $(APRON_LIB)
-	for i in $(LIB_FILES); do if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; done
+	for i in $(LIB_FILES); do if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i;  fi; done
 ifneq ($(HAS_DEBUG),)
 	for i in $(LIB_FILES_DEBUG); do if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); fi; done
 endif

--- a/apronxx/Makefile
+++ b/apronxx/Makefile
@@ -85,7 +85,9 @@ distclean: clean
 install:
 	$(INSTALLd) $(APRON_INCLUDE) $(APRON_INCLUDE)/apronxx $(APRON_LIB)
 	$(INSTALL) $(CCINC) $(APRON_INCLUDE)/apronxx
-	$(INSTALLSTRIP) $(CCLIB_TO_INSTALL) $(APRON_LIB)
+	for i in $(CCLIB_TO_INSTALL); do \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
+	done
 ifneq ($(HAS_DEBUG),)
 	$(INSTALL) $(CCLIB_TO_INSTALL_DEBUG) $(APRON_LIB)
 endif

--- a/avoct/Makefile
+++ b/avoct/Makefile
@@ -132,10 +132,10 @@ install:
 	$(INSTALL) avo.h $(APRON_INCLUDE)
 	$(INSTALL) $(CCINC) $(APRON_INCLUDE)/avo
 	for i in avotop* avorun*; do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_BIN); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_BIN); $(STRIP) $(APRON_BIN)/$$i; fi; \
 	done
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 ifeq ($(OCAMLFIND),)
 	for i in $(CAMLLIB_TO_INSTALL); do \

--- a/box/Makefile
+++ b/box/Makefile
@@ -105,7 +105,7 @@ install: $(CCINC_TO_INSTALL) $(CCLIB_TO_INSTALL)
 	$(INSTALLd) $(APRON_INCLUDE) $(APRON_LIB)
 	$(INSTALL) $(CCINC_TO_INSTALL) $(APRON_INCLUDE)
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 ifeq ($(OCAMLFIND),)
 	for i in $(CAML_TO_INSTALL); do \

--- a/configure
+++ b/configure
@@ -71,7 +71,7 @@ has_java=1
 force_absolute_dylib_install_names=0;
 ext_dll=so
 has_debug=0
-do_strip=--strip
+strip="strip --strip-unneeded"
 while : ; do
     case "$1" in
         "") 
@@ -126,7 +126,7 @@ while : ; do
         -debug|--debug)
             has_debug=1;;
         -no-strip|--no-strip)
-            do_strip=;;
+            strip=echo;;
         -help|--help)
             help;;
         *)
@@ -612,7 +612,8 @@ detected configuration:
    
    installation path            $apron_prefix
    dynamic libraries extension  $ext_dll
-   install (stripped) command   $install ($do_strip)
+   install command              $install
+   strip command                $strip
 
 EOF
 
@@ -690,7 +691,7 @@ RANLIB = $ranlib
 SED = $sed
 PERL = perl
 INSTALL = $install
-INSTALLSTRIP = $install $do_strip
+STRIP = $strip
 INSTALLd = $install -d
 
 CAML_PREFIX = $caml_prefix

--- a/fppol/Makefile
+++ b/fppol/Makefile
@@ -132,10 +132,10 @@ install:
 	$(INSTALL) fpp.h $(APRON_INCLUDE)
 	$(INSTALL) $(CCINC) $(APRON_INCLUDE)/fpp
 	for i in fpptop* fpprun*; do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_BIN); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_BIN); $(STRIP) $(APRON_BIN)/$$i; fi; \
 	done
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 ifeq ($(OCAMLFIND),)
 	for i in $(CAMLLIB_TO_INSTALL); do \

--- a/itv/Makefile
+++ b/itv/Makefile
@@ -87,10 +87,10 @@ install: $(CCINC_TO_INSTALL) $(CCLIB_TO_INSTALL)
 	$(INSTALLd) $(APRON_INCLUDE) $(APRON_LIB)
 	$(INSTALL) $(CCINC_TO_INSTALL) $(APRON_INCLUDE)
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 #	for i in $(CCBIN_TO_INSTALL); do \
-#		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_BIN); fi; \
+#		if test -f $$i; then $(INSTALL) $$i $(APRON_BIN); $(STRIP) $(APRON_BIN)/$$i; fi; \
 #	done
 ifneq ($(HAS_DEBUG),)
 	for i in $(CCLIB_TO_INSTALL_DEBUG); do \

--- a/japron/Makefile
+++ b/japron/Makefile
@@ -181,7 +181,7 @@ doc:
 install:
 	$(INSTALLd) $(APRON_LIB); \
 	for i in $(SOINST); do \
-		$(INSTALLSTRIP) $$i $(APRON_LIB); \
+		$(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; \
 	done; \
 	$(INSTALLd) $(JAVA_PREFIX); \
 	for i in $(JAVAINST); do \

--- a/newpolka/Makefile
+++ b/newpolka/Makefile
@@ -119,7 +119,7 @@ install:
 	$(INSTALLd) $(APRON_INCLUDE) $(APRON_LIB)
 	$(INSTALL) $(CCINC_TO_INSTALL) $(APRON_INCLUDE)
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 ifeq ($(OCAMLFIND),)
 	for i in $(CAML_TO_INSTALL); do \

--- a/octagons/Makefile
+++ b/octagons/Makefile
@@ -131,10 +131,10 @@ install:
 	$(INSTALL) oct.h $(APRON_INCLUDE)
 	$(INSTALL) $(CCINC) $(APRON_INCLUDE)/oct
 	for i in octtop* octrun*; do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_BIN); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_BIN); $(STRIP) $(APRON_BIN)/$$i; fi; \
 	done
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 ifeq ($(OCAMLFIND),)
 	for i in $(CAMLLIB_TO_INSTAL); do \

--- a/ppl/Makefile
+++ b/ppl/Makefile
@@ -81,7 +81,7 @@ install:
 	$(INSTALLd) $(APRON_INCLUDE) $(APRON_LIB) $(APRON_BIN)
 	$(INSTALL) ap_ppl.h $(APRON_INCLUDE)
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 ifneq ($(HAS_OCAML),)
 ifeq ($(OCAMLFIND),)

--- a/pplite/Makefile
+++ b/pplite/Makefile
@@ -93,7 +93,7 @@ install:
 	$(INSTALLd) $(APRON_INCLUDE) $(APRON_LIB) $(APRON_BIN)
 	$(INSTALL) ap_pplite.h $(APRON_INCLUDE)
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 ifeq ($(OCAMLFIND),)
 	for i in $(CAMLLIB_TO_INSTALL); do \

--- a/products/Makefile
+++ b/products/Makefile
@@ -86,7 +86,7 @@ install:
 	$(INSTALLd) $(APRON_INCLUDE) $(APRON_LIB)
 	$(INSTALL) $(CCINC_TO_INSTALL) $(APRON_INCLUDE)
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 ifeq ($(OCAMLFIND),)
 	for i in $(CAMLLIB_TO_INSTALL); do \

--- a/taylor1plus/Makefile
+++ b/taylor1plus/Makefile
@@ -135,7 +135,7 @@ install: $(CCINC_TO_INSTALL) $(CCLIB_TO_INSTALL)
 	$(INSTALLd) $(APRON_INCLUDE) $(APRON_LIB)
 	$(INSTALL) $(CCINC_TO_INSTALL) $(APRON_INCLUDE)
 	for i in $(CCLIB_TO_INSTALL); do \
-		if test -f $$i; then $(INSTALLSTRIP) $$i $(APRON_LIB); fi; \
+		if test -f $$i; then $(INSTALL) $$i $(APRON_LIB); $(STRIP) $(APRON_LIB)/$$i; fi; \
 	done
 ifeq ($(OCAMLFIND),)
 	for i in $(CAML_TO_INSTALL); do \


### PR DESCRIPTION
Using plain `strip` is too aggressive for static libraries and prevents linking.

Ths PR changes the installation method to call `strip --strip-unneeded` on all installed libraries and binaries.
