### PR TITLE
Fix library search on recent Mac (ARM) with homebrew

### DIFF
--- a/configure
+++ b/configure
@@ -233,7 +233,7 @@ checkprefix()
         fi
     fi
     # check with a prefix
-    for prefix in $testprefix /usr/local /opt/homebrew "$HOME"
+    for prefix in $testprefix /usr/local /opt/homebrew /usr "$HOME"
     do
         echo "looking for $testlib in prefix $prefix"
         checkinc "$testcc -I$prefix/include" "$testinc"

--- a/configure
+++ b/configure
@@ -233,7 +233,7 @@ checkprefix()
         fi
     fi
     # check with a prefix
-    for prefix in $testprefix /usr/local /usr "$HOME"
+    for prefix in $testprefix /usr/local /opt/homebrew "$HOME"
     do
         echo "looking for $testlib in prefix $prefix"
         checkinc "$testcc -I$prefix/include" "$testinc"


### PR DESCRIPTION
This PR attempts to fix regression on recent (ARM) Mac due to homebrew changing its default installation path. We simply adds `/opt/homebew` to the list of hardcoded paths searched by configure.