### PR TITLE
fix: ppl detection on freebsd

### DIFF
--- a/apron.opam
+++ b/apron.opam
@@ -17,7 +17,6 @@ build: [
     "--prefix"
     "%{share}%/apron"
     "--no-ppl" {!conf-ppl:installed}
-    "--no-ocaml-plugins" {os = "freebsd"}
     "--absolute-dylibs" {os = "macos"}
     "--ext-dll" {os = "win32"} "dll" {os = "win32"}
     "--debug"

--- a/configure
+++ b/configure
@@ -391,6 +391,17 @@ then
     cxxflags=$acc
 fi
 
+case $(uname -s)
+in
+    FreeBSD)
+    # FreeBSD (at least 14) required the c++ standard to be c++11 to compile.
+    cxxflags="-std=c++11 $cxxflags"
+    ;;
+    *)
+    ;;
+esac
+
+
 
 # tools
 


### PR DESCRIPTION
Dear maintainer,

This PR aims to fix the ppl library detection on FreeBSD.  

It appears that on FreeBSD.14 (the version that I use), ppl is not detected despite being installed. 

The compilation fails (which also fails the `configure` ppl detection) if the c++ -std option is not explicitly set to `-std=c++11`

Thank for your time,
Sincerely yours